### PR TITLE
feat: add useGalleryImages React Query hook

### DIFF
--- a/frontend/lib/hooks/useGalleryImages.ts
+++ b/frontend/lib/hooks/useGalleryImages.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import { galleryApi } from "@/lib/api/api";
+import { GalleryImage } from "@/lib/api/admin";
+
+export function useGalleryImages() {
+return useQuery({
+queryKey: ["gallery-images"],
+queryFn: async () => {
+const response = await galleryApi.getImages();
+if (response.success && response.data) {
+return response.data;
+}
+throw new Error(response.error || "Failed to load gallery images");
+},
+staleTime: 5 _ 60 _ 1000,
+gcTime: 30 _ 60 _ 1000,
+retry: 2,
+});
+}


### PR DESCRIPTION
## PR Title

**Add `useGalleryImages` React Query hook for shared gallery data**

## Description

This PR adds a reusable `useGalleryImages` hook built with **React Query** to fetch and cache gallery images used across public-facing areas of the application (gallery page, homepage sections, showcases, etc.).

The hook centralizes gallery data access and ensures consistent error handling, caching, and request deduplication across all consumers.

## What’s Included

* New `useGalleryImages` hook powered by React Query
* Shared query cache across all components using the hook
* Standardized loading and error states
* Centralized gallery API fetching logic
* Improved performance via caching and background refetching

## Why

* Eliminates duplicated gallery-fetching logic
* Ensures consistent gallery data across the app
* Improves performance and reduces unnecessary network requests
* Simplifies UI components by abstracting data concerns

## Usage Example

```ts
const { data, isLoading, error } = useGalleryImages();
```

## Implementation Notes

* Uses React Query’s `useQuery` for caching and synchronization
* Stable query key to allow cache sharing across all consumers
* Easy to extend with pagination, filters, or revalidation options

## Screens / Testing

* [ ] Manually tested on gallery page
* [ ] Verified cache sharing between multiple components
* [ ] Confirmed error and loading states

## Related Issue

Closes  #54

