### PR TITLE
feat(auth): add useRoleProtection hook for role-based access control

### DIFF
--- a/frontend/lib/hooks/useRoleProtection.ts
+++ b/frontend/lib/hooks/useRoleProtection.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuthStore } from "@/lib/store/authStore";
+import { AdminRole } from "@/lib/types/user";
+
+interface UseRoleProtectionOptions {
+allowedRoles: AdminRole[];
+redirectTo?: string;
+}
+
+export function useRoleProtection({
+allowedRoles,
+redirectTo = "/admin/dashboard",
+}: UseRoleProtectionOptions) {
+const router = useRouter();
+const { user, isLoading } = useAuthStore();
+
+useEffect(() => {
+// Wait for auth to load
+if (isLoading) return;
+
+    // If no user, redirect to login (handled by auth middleware)
+    if (!user) return;
+
+    // Check if user's role is in allowed roles
+    const hasAccess = user.role && allowedRoles.includes(user.role);
+
+    if (!hasAccess) {
+      console.warn(
+        `Access denied: User role '${user.role}' not in allowed roles`,
+        allowedRoles
+      );
+      router.replace(redirectTo);
+    }
+
+}, [user, isLoading, allowedRoles, redirectTo, router]);
+
+// Return access status
+return {
+hasAccess: user?.role ? allowedRoles.includes(user.role) : false,
+isLoading,
+user,
+};
+}


### PR DESCRIPTION
## PR Title

**Implement `useRoleProtection` hook for role-based route access**

## Description

This PR introduces a reusable client-side hook, `useRoleProtection`, to enforce **role-based access control** for protected admin routes.

The hook centralizes role validation logic that was previously scattered across pages, ensuring consistent behavior and simplifying protected route implementations.


## Hook API

```ts
interface UseRoleProtectionOptions {
  allowedRoles: AdminRole[];
  redirectTo?: string;
}
```

## Behavior & Logic

Inside a `useEffect`, the hook:

1. Reads auth state from `useAuthStore`:

   * `user`
   * `isLoading`
2. If `isLoading` is `true` → waits for auth resolution
3. If no `user` exists → does nothing (login redirect handled elsewhere)
4. If a user exists:

   * Checks if `user.role` is included in `allowedRoles`
   * If not allowed:

     * Logs a warning to the console
     * Redirects using `router.replace(redirectTo)`

### Defaults

* `redirectTo` defaults to:

  ```
  /admin/dashboard
  ```

## Returned Values

The hook returns:

```ts
{
  hasAccess: boolean;
  isLoading: boolean;
  user: AuthUser | null;
}
```

This allows consuming components to:

* Display loaders while auth state is resolving
* Conditionally render protected content based on `hasAccess`

## Example Usage

```ts
const { hasAccess, isLoading } = useRoleProtection({
  allowedRoles: ["ADMIN", "SUPER_ADMIN"],
});
```

closes #51 
