### PR TITLE
feat(menu): add useMenuItems React Query hook

### DIFF
--- a/frontend/lib/hooks/useMenuItems.ts
+++ b/frontend/lib/hooks/useMenuItems.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+import { menuApi } from "@/lib/api/api";
+
+export function useMenuItems() {
+return useQuery({
+queryKey: ["menu-items"],
+queryFn: async () => {
+const response = await menuApi.getAll();
+if (response.success && response.data) {
+return response.data;
+}
+throw new Error(response.error || "Failed to load menu items");
+},
+staleTime: 5 _ 60 _ 1000,
+gcTime: 30 _ 60 _ 1000,
+retry: 2,
+});
+}


### PR DESCRIPTION
**Implement `useMenuItems` React Query Hook**

---

## 📝 Pull Request Description

### Summary

This PR introduces a reusable `useMenuItems` hook powered by React Query to fetch menu items from the backend. The hook serves as the single source of truth for menu item data across the frontend and standardizes loading, caching, and error handling.

### Changes

* Added `useMenuItems` hook using React Query
* Centralized menu item fetching logic
* Enabled built-in caching, loading, and error states
* Prepared the hook for reuse across multiple components


### Usage

```ts
const { data, isLoading, error } = useMenuItems();
```



Closes #52

