### PR TITLE
Add reusable analytics metric card component

### DIFF
--- a/frontend/app/components/admin/analytics/MetricCard.tsx
+++ b/frontend/app/components/admin/analytics/MetricCard.tsx
@@ -1,0 +1,65 @@
+// frontend/src/components/admin/analytics/MetricCard.tsx
+"use client";
+
+import React from "react";
+import { LucideIcon } from "lucide-react";
+import { motion } from "framer-motion";
+import { cn } from "@/lib/utils";
+
+interface MetricCardProps {
+  title: string;
+  value: string | number;
+  change?: {
+    value: number;
+    label: string;
+    isPositive?: boolean;
+  };
+  icon: LucideIcon;
+  iconColor?: string;
+  iconBgColor?: string;
+  delay?: number;
+}
+
+export function MetricCard({
+  title,
+  value,
+  change,
+  icon: Icon,
+  iconColor = "text-orange-600",
+  iconBgColor = "bg-orange-100",
+  delay = 0,
+}: MetricCardProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.3, delay }}
+      className="bg-white rounded-xl border border-gray-200 p-6"
+    >
+      <div className="flex items-start justify-between">
+        <div className="flex-1">
+          <p className="text-sm font-medium text-gray-600 mb-1">{title}</p>
+          <h3 className="text-3xl font-bold text-gray-900 mb-2">{value}</h3>
+
+          {change && (
+            <div className="flex items-center gap-1">
+              <span
+                className={cn(
+                  "text-sm font-medium",
+                  change.isPositive ? "text-green-600" : "text-red-600"
+                )}
+              >
+                {change.isPositive ? "↑" : "↓"} {Math.abs(change.value)}%
+              </span>
+              <span className="text-sm text-gray-500">{change.label}</span>
+            </div>
+          )}
+        </div>
+
+        <div className={cn("p-3 rounded-lg", iconBgColor)}>
+          <Icon className={cn("w-6 h-6", iconColor)} />
+        </div>
+      </div>
+    </motion.div>
+  );
+}


### PR DESCRIPTION
Description:
Introduces a reusable MetricCard component for the analytics dashboard, designed to display key metrics with optional change indicators. Supports configurable props including value, icon, and change data with positive/negative states.

Includes a clean card layout with an icon highlight, conditional styling for change direction (green/red), and a staggered animation system using a configurable delay. Built as a client component with framer-motion for smooth entry transitions and cn() for flexible class handling.

closes #175 