### PR TITLE
fix: add children prop to ToastProvider to resolve CI build error

### DIFF
--- a/frontend/app/(auth)/admin/users/new/page.tsx
+++ b/frontend/app/(auth)/admin/users/new/page.tsx
@@ -15,7 +15,7 @@ const schema = z.object({
   email: z.string().email("Valid email required"),
   password: z.string().min(8, "Password must be at least 8 characters"),
   role: z.enum([AdminRole.STAFF, AdminRole.MANAGER, AdminRole.ADMIN], {
-    required_error: "Role is required",
+    message: "Role is required",
   }),
 });
 

--- a/frontend/app/(public)/admin-regitration/page.tsx
+++ b/frontend/app/(public)/admin-regitration/page.tsx
@@ -15,7 +15,7 @@ const schema = z.object({
   email: z.string().email("Valid email required"),
   password: z.string().min(8, "Password must be at least 8 characters"),
   role: z.enum([AdminRole.STAFF, AdminRole.MANAGER, AdminRole.ADMIN], {
-    required_error: "Role is required",
+    message: "Role is required",
   }),
 });
 

--- a/frontend/providers/ToastProvider.tsx
+++ b/frontend/providers/ToastProvider.tsx
@@ -1,11 +1,14 @@
 // frontend/src/providers/ToastProvider.tsx
 "use client";
 
+import { ReactNode } from "react";
 import { Toaster } from "react-hot-toast";
 
-export function ToastProvider() {
+export function ToastProvider({ children }: { children?: ReactNode }) {
   return (
-    <Toaster
+    <>
+      {children}
+      <Toaster
       position="top-right"
       toastOptions={{
         duration: 4000,
@@ -31,5 +34,6 @@ export function ToastProvider() {
         },
       }}
     />
+    </>
   );
 }


### PR DESCRIPTION
## Problem
The frontend CI build was failing with:
`````nType error: Type '{ children: Element; }' has no properties in common with type 'IntrinsicAttributes'.
````` 
at pp/(auth)/admin/layout.tsx:17 where <ToastProvider> wraps children.

## Fix
Added children?: ReactNode prop to ToastProvider and render it inside a React fragment alongside <Toaster />.