### PR TITLE
feat: strict TypeScript types, Zod validation, noImplicitAny [FE-08]

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -544,9 +544,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "ff"

--- a/frontend/hooks/useAdminQueries.ts
+++ b/frontend/hooks/useAdminQueries.ts
@@ -1,0 +1,89 @@
+/**
+ * Type-safe React Query hooks for admin endpoints.
+ * Every useQuery / useMutation call has explicit generic type parameters.
+ */
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "@/lib/api/client";
+import {
+  MenuItemListSchema,
+  GalleryImageListSchema,
+  AdminUserListSchema,
+  DashboardStatsSchema,
+  AnalyticsSchema,
+} from "@/lib/schemas/api.schemas";
+import type {
+  MenuItem,
+  GalleryImage,
+  AdminUser,
+  DashboardStats,
+  Analytics,
+} from "@/lib/schemas/api.schemas";
+import type { ApiError, MutationSuccessResponse } from "@/lib/types/api";
+import { toast } from "sonner";
+
+// ── Menu ───────────────────────────────────────────────────────────────────
+
+export function useMenuItems() {
+  return useQuery<MenuItem[], ApiError>({
+    queryKey: ["admin", "menu"],
+    queryFn: () =>
+      apiClient<MenuItem[]>("/api/admin/menu", {}, MenuItemListSchema),
+  });
+}
+
+export function useUpdateMenuItem() {
+  const queryClient = useQueryClient();
+  return useMutation<MutationSuccessResponse, ApiError, { id: string; isActive: boolean }>({
+    mutationFn: ({ id, isActive }) =>
+      apiClient<MutationSuccessResponse>(`/api/admin/menu/${id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ isActive }),
+      }),
+    onError: (err) => toast.error(err.message),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ["admin", "menu"] }),
+  });
+}
+
+// ── Gallery ────────────────────────────────────────────────────────────────
+
+export function useGalleryImages() {
+  return useQuery<GalleryImage[], ApiError>({
+    queryKey: ["admin", "gallery"],
+    queryFn: () =>
+      apiClient<GalleryImage[]>("/api/admin/gallery", {}, GalleryImageListSchema),
+  });
+}
+
+// ── Admin users ────────────────────────────────────────────────────────────
+
+export function useAdminUsers() {
+  return useQuery<AdminUser[], ApiError>({
+    queryKey: ["admin", "users"],
+    queryFn: () =>
+      apiClient<AdminUser[]>("/api/admin/users", {}, AdminUserListSchema),
+  });
+}
+
+// ── Dashboard stats ────────────────────────────────────────────────────────
+
+export function useDashboardStats() {
+  return useQuery<DashboardStats, ApiError>({
+    queryKey: ["admin", "dashboard"],
+    queryFn: () =>
+      apiClient<DashboardStats>("/api/admin/dashboard", {}, DashboardStatsSchema),
+  });
+}
+
+// ── Analytics ──────────────────────────────────────────────────────────────
+
+export function useAnalytics(period: string) {
+  return useQuery<Analytics, ApiError>({
+    queryKey: ["admin", "analytics", period],
+    queryFn: () =>
+      apiClient<Analytics>(
+        `/api/admin/analytics?period=${period}`,
+        {},
+        AnalyticsSchema
+      ),
+  });
+}

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+import type { ApiError } from "@/lib/types/api";
+import { toast } from "sonner";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+
+function handleUnauthorized(): void {
+  document.cookie = "token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
+  localStorage.removeItem("auth-token");
+  toast.error("Session expired. Please log in again.");
+  if (typeof window !== "undefined") {
+    window.location.href = "/login";
+  }
+}
+
+/**
+ * Type-safe fetch wrapper.
+ *
+ * Optionally accepts a Zod schema — when provided, the response JSON is
+ * parsed and validated before being returned. A ZodError is thrown (with
+ * the field name) if the shape doesn't match, so mismatches surface before
+ * reaching component state.
+ */
+export async function apiClient<T = unknown>(
+  path: string,
+  init: RequestInit = {},
+  schema?: z.ZodType<T>
+): Promise<T> {
+  const token =
+    typeof window !== "undefined"
+      ? localStorage.getItem("auth-token")
+      : null;
+
+  const headers = new Headers(init.headers);
+  headers.set("Content-Type", "application/json");
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`${API_BASE_URL}${path}`, { ...init, headers });
+  } catch {
+    toast.error("Connection error. Please check your network.");
+    throw new Error("Network error");
+  }
+
+  if (response.status === 401) {
+    handleUnauthorized();
+    throw new Error("Unauthorized");
+  }
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    let parsed: Partial<ApiError> = {};
+    try {
+      parsed = JSON.parse(errorBody) as Partial<ApiError>;
+    } catch {
+      // non-JSON error body
+    }
+    throw new Error(parsed.message ?? `HTTP ${response.status}`);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  const json: unknown = await response.json();
+
+  // Runtime Zod validation — throws ZodError with field name on mismatch
+  if (schema) {
+    return schema.parse(json);
+  }
+
+  return json as T;
+}

--- a/frontend/lib/schemas/api.schemas.ts
+++ b/frontend/lib/schemas/api.schemas.ts
@@ -85,7 +85,7 @@ export const AnalyticsSchema = z.object({
 export const ApiErrorSchema = z.object({
   statusCode: z.number().int(),
   message: z.string(),
-  details: z.record(z.array(z.string())).optional(),
+  details: z.record(z.string(), z.array(z.string())).optional(),
 });
 
 // ── Inferred types (single source of truth) ────────────────────────────────

--- a/frontend/lib/schemas/api.schemas.ts
+++ b/frontend/lib/schemas/api.schemas.ts
@@ -1,0 +1,97 @@
+import { z } from "zod";
+
+// ── MenuItemResponse ───────────────────────────────────────────────────────
+
+export const MenuItemSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  description: z.string().nullable(),
+  price: z.number(),
+  isActive: z.boolean(),
+  category: z.string().nullable(),
+  imageUrl: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const MenuItemListSchema = z.array(MenuItemSchema);
+
+// ── GalleryImageResponse ───────────────────────────────────────────────────
+
+export const GalleryImageSchema = z.object({
+  id: z.string().uuid(),
+  url: z.string().url(),
+  caption: z.string().nullable(),
+  order: z.number().int(),
+  createdAt: z.string(),
+});
+
+export const GalleryImageListSchema = z.array(GalleryImageSchema);
+
+// ── AdminUserResponse ──────────────────────────────────────────────────────
+
+export const AdminUserSchema = z.object({
+  id: z.string().uuid(),
+  firstname: z.string(),
+  lastname: z.string(),
+  email: z.string().email(),
+  role: z.string(),
+  isVerified: z.boolean(),
+  isActive: z.boolean(),
+  membershipStatus: z.string(),
+  profilePicture: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+export const AdminUserListSchema = z.array(AdminUserSchema);
+
+// ── DashboardStatsResponse ─────────────────────────────────────────────────
+
+export const DashboardStatsSchema = z.object({
+  totalBookings: z.number().int(),
+  totalRevenue: z.number(),
+  activeMembers: z.number().int(),
+  occupancyRate: z.number(),
+  recentActivity: z.array(
+    z.object({
+      id: z.string(),
+      type: z.string(),
+      description: z.string(),
+      createdAt: z.string(),
+    })
+  ),
+});
+
+// ── AnalyticsResponse ──────────────────────────────────────────────────────
+
+export const AnalyticsSchema = z.object({
+  period: z.string(),
+  bookings: z.number().int(),
+  revenue: z.number(),
+  newMembers: z.number().int(),
+  churnRate: z.number(),
+  topWorkspaces: z.array(
+    z.object({
+      id: z.string().uuid(),
+      name: z.string(),
+      bookingCount: z.number().int(),
+      revenueKobo: z.number().int(),
+    })
+  ),
+});
+
+// ── ApiError ───────────────────────────────────────────────────────────────
+
+export const ApiErrorSchema = z.object({
+  statusCode: z.number().int(),
+  message: z.string(),
+  details: z.record(z.array(z.string())).optional(),
+});
+
+// ── Inferred types (single source of truth) ────────────────────────────────
+
+export type MenuItem = z.infer<typeof MenuItemSchema>;
+export type GalleryImage = z.infer<typeof GalleryImageSchema>;
+export type AdminUser = z.infer<typeof AdminUserSchema>;
+export type DashboardStats = z.infer<typeof DashboardStatsSchema>;
+export type Analytics = z.infer<typeof AnalyticsSchema>;

--- a/frontend/lib/types/api.ts
+++ b/frontend/lib/types/api.ts
@@ -1,0 +1,117 @@
+// Strict TypeScript interfaces for every API response shape.
+// Zero use of `any` — all shapes are explicitly typed.
+
+// ── Shared primitives ──────────────────────────────────────────────────────
+
+export type ApiError = {
+  statusCode: number;
+  message: string;
+  details?: Record<string, string[]>;
+};
+
+// ── Dashboard / Analytics ──────────────────────────────────────────────────
+
+export interface DashboardStatsResponse {
+  totalBookings: number;
+  totalRevenue: number;
+  activeMembers: number;
+  occupancyRate: number;
+  recentActivity: ActivityItem[];
+}
+
+export interface ActivityItem {
+  id: string;
+  type: string;
+  description: string;
+  createdAt: string;
+}
+
+export interface AnalyticsResponse {
+  period: string;
+  bookings: number;
+  revenue: number;
+  newMembers: number;
+  churnRate: number;
+  topWorkspaces: WorkspaceStats[];
+}
+
+export interface WorkspaceStats {
+  id: string;
+  name: string;
+  bookingCount: number;
+  revenueKobo: number;
+}
+
+// ── Menu ───────────────────────────────────────────────────────────────────
+
+export interface MenuItemResponse {
+  id: string;
+  name: string;
+  description: string | null;
+  price: number;
+  isActive: boolean;
+  category: string | null;
+  imageUrl: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ── Gallery ────────────────────────────────────────────────────────────────
+
+export interface GalleryImageResponse {
+  id: string;
+  url: string;
+  caption: string | null;
+  order: number;
+  createdAt: string;
+}
+
+// ── Admin users ────────────────────────────────────────────────────────────
+
+export interface AdminUserResponse {
+  id: string;
+  firstname: string;
+  lastname: string;
+  email: string;
+  role: string;
+  isVerified: boolean;
+  isActive: boolean;
+  membershipStatus: string;
+  profilePicture: string | null;
+  createdAt: string;
+}
+
+// ── Contact submissions ────────────────────────────────────────────────────
+
+export interface ContactSubmissionResponse {
+  id: string;
+  name: string;
+  email: string;
+  subject: string;
+  message: string;
+  status: "new" | "read" | "replied";
+  createdAt: string;
+}
+
+// ── Paginated wrapper ──────────────────────────────────────────────────────
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  total: number;
+  page: number;
+  perPage: number;
+}
+
+// ── Auth ───────────────────────────────────────────────────────────────────
+
+export interface AuthResponse {
+  accessToken: string;
+  user: AdminUserResponse;
+}
+
+// ── Generic mutation response ──────────────────────────────────────────────
+
+export interface MutationSuccessResponse {
+  message: string;
+  data?: unknown;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,6 +5,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    "noImplicitAny": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
## Summary

Eliminates all `any` usage from the API layer by introducing strict response interfaces, Zod runtime validation, and enabling `noImplicitAny` in `tsconfig.json`.

## Files Changed

### New
- `frontend/lib/types/api.ts` — strict interfaces for every endpoint: `DashboardStatsResponse`, `MenuItemResponse`, `AdminUserResponse`, `GalleryImageResponse`, `ContactSubmissionResponse`, `AnalyticsResponse`, `ApiError`, `PaginatedResponse<T>`
- `frontend/lib/schemas/api.schemas.ts` — Zod schemas for the 5 most critical responses (Menu, Gallery, AdminUser, DashboardStats, Analytics); inferred types exported as single source of truth
- `frontend/lib/api/client.ts` — updated fetch wrapper; optional `schema?: z.ZodType<T>` parameter; throws `ZodError` with field name if shape mismatches before reaching component state
- `frontend/hooks/useAdminQueries.ts` — all `useQuery`/`useMutation` calls with explicit generic type parameters `useQuery<MenuItem[], ApiError>`

### Modified
- `frontend/tsconfig.json` — added `"noImplicitAny": true`

## Acceptance Criteria

- [x] Zero uses of `any` in `frontend/lib/api/`
- [x] TypeScript compile error if a component accesses a field not in the response interface
- [x] Mismatched backend response throws a `ZodError` with the field name
- [x] `noImplicitAny: true` in `tsconfig.json`
- [x] All `useQuery`/`useMutation` calls have explicit generic type parameters

closes #276