### PR TITLE
[FE-02] Enforce auth on admin routes via Next.js middleware

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -544,9 +544,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "ff"

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from "next/server";
+import { jwtVerify } from "jose";
+
+// Routes that require authentication
+const PROTECTED_PREFIX = "/admin";
+
+// Routes that are always public — never intercepted
+const PUBLIC_PREFIXES = [
+  "/api/",
+  "/_next/",
+  "/menu",
+  "/login",
+  "/register",
+  "/favicon.ico",
+];
+
+// Role hierarchy: a role can access its own level and below
+const ROLE_HIERARCHY: Record<string, number> = {
+  super_admin: 3,
+  admin: 2,
+  staff: 1,
+  user: 0,
+};
+
+// Route-to-minimum-role mapping. More specific paths take priority.
+const ROUTE_ROLE_MAP: Array<{ prefix: string; minRole: string }> = [
+  { prefix: "/admin/users", minRole: "admin" },
+  { prefix: "/admin/settings", minRole: "super_admin" },
+  { prefix: "/admin/billing", minRole: "super_admin" },
+  { prefix: "/admin", minRole: "staff" },
+];
+
+function getSecret(): Uint8Array {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) throw new Error("JWT_SECRET is not configured");
+  return new TextEncoder().encode(secret);
+}
+
+function isPublicRoute(pathname: string): boolean {
+  return PUBLIC_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
+
+function requiredRoleForPath(pathname: string): string | null {
+  for (const entry of ROUTE_ROLE_MAP) {
+    if (pathname.startsWith(entry.prefix)) return entry.minRole;
+  }
+  return null;
+}
+
+function hasRole(userRole: string, requiredRole: string): boolean {
+  return (ROLE_HIERARCHY[userRole] ?? -1) >= (ROLE_HIERARCHY[requiredRole] ?? 999);
+}
+
+export async function middleware(request: NextRequest): Promise<NextResponse> {
+  const { pathname } = request.nextUrl;
+
+  // Skip public routes immediately
+  if (isPublicRoute(pathname)) return NextResponse.next();
+
+  // Only intercept admin routes
+  if (!pathname.startsWith(PROTECTED_PREFIX)) return NextResponse.next();
+
+  const token = request.cookies.get("accessToken")?.value;
+
+  if (!token) {
+    const loginUrl = request.nextUrl.clone();
+    loginUrl.pathname = "/login";
+    loginUrl.searchParams.set("redirect", pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  try {
+    const { payload } = await jwtVerify(token, getSecret());
+
+    const userRole = (payload.role as string) ?? "user";
+    const requiredRole = requiredRoleForPath(pathname);
+
+    if (requiredRole && !hasRole(userRole, requiredRole)) {
+      const dashboardUrl = request.nextUrl.clone();
+      dashboardUrl.pathname = "/admin/dashboard";
+      dashboardUrl.search = "";
+      return NextResponse.redirect(dashboardUrl);
+    }
+
+    return NextResponse.next();
+  } catch {
+    // Token is expired or invalid — redirect to login
+    const loginUrl = request.nextUrl.clone();
+    loginUrl.pathname = "/login";
+    loginUrl.searchParams.set("redirect", pathname);
+    const response = NextResponse.redirect(loginUrl);
+    response.cookies.delete("accessToken");
+    return response;
+  }
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths EXCEPT:
+     * - _next/static (static files)
+     * - _next/image  (image optimisation)
+     * - favicon.ico
+     * - public assets (png, jpg, svg, etc.)
+     */
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:png|jpg|jpeg|gif|svg|ico|webp)).*)",
+  ],
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "date-fns": "^4.1.0",
         "embla-carousel-react": "^8.6.0",
         "framer-motion": "^12.23.24",
+        "jose": "^5.9.6",
         "lucide-react": "^0.562.0",
         "next": "15.5.9",
         "next-seo": "^7.0.1",
@@ -1362,6 +1363,66 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",
@@ -4675,6 +4736,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "date-fns": "^4.1.0",
     "embla-carousel-react": "^8.6.0",
     "framer-motion": "^12.23.24",
+    "jose": "^5.9.6",
     "lucide-react": "^0.562.0",
     "next": "15.5.9",
     "next-seo": "^7.0.1",


### PR DESCRIPTION
## Summary

Replaces the bypassable client-only ProtectedRoute guard with a server-side Next.js middleware that enforces authentication and role checks before any page content is delivered to the browser.

### Changes
- frontend/middleware.ts intercepts all /admin/* requests
- Reads the accessToken cookie and verifies it with jose (jwtVerify + JWT_SECRET)
- Redirects unauthenticated requests to /login?redirect={originalPath}
- Clears stale cookie on token expiry before redirecting
- Enforces role-based access via ROUTE_ROLE_MAP (e.g. /admin/settings requires super_admin)
- Redirects role-violations to /admin/dashboard instead of showing a blank screen
- Matcher config excludes _next/static, _next/image, favicon.ico, and all static assets

closes #270