### PR TITLE
feat(FE-09): real-time order notifications via Socket.io

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
         "@nestjs/mapped-types": "*",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.1.12",
+        "@nestjs/platform-socket.io": "^11.1.12",
         "@nestjs/schedule": "^6.1.0",
         "@nestjs/throttler": "^6.5.0",
         "@nestjs/typeorm": "^11.0.0",
@@ -1068,7 +1069,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -3434,7 +3434,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.12.tgz",
       "integrity": "sha512-v6U3O01YohHO+IE3EIFXuRuu3VJILWzyMmSYZXpyBbnp0hk0mFyHxK2w3dF4I5WnbwiRbWlEXdeXFvPQ7qaZzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -3482,7 +3481,6 @@
       "integrity": "sha512-97DzTYMf5RtGAVvX1cjwpKRiCUpkeQ9CCzSAenqkAhOmNVVFaApbhuw+xrDt13rsCa2hHVOYPrV4dBgOYMJjsA==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -3566,7 +3564,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.12.tgz",
       "integrity": "sha512-GYK/vHI0SGz5m8mxr7v3Urx8b9t78Cf/dj5aJMZlGd9/1D9OI1hAl00BaphjEXINUJ/BQLxIlF2zUjrYsd6enQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.2.1",
@@ -3581,6 +3578,25 @@
       "peerDependencies": {
         "@nestjs/common": "^11.0.0",
         "@nestjs/core": "^11.0.0"
+      }
+    },
+    "node_modules/@nestjs/platform-socket.io": {
+      "version": "11.1.28",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.28.tgz",
+      "integrity": "sha512-vY+GmU2jBcymvgm5rEnftUx4qNxK8cDJmXjl1/1NcpITTNJo0vg07xYR43MwXHcMqe7b0jwqt5+UCTzxqQFIqA==",
+      "license": "MIT",
+      "dependencies": {
+        "socket.io": "4.8.3",
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/websockets": "^11.0.0",
+        "rxjs": "^7.1.0"
       }
     },
     "node_modules/@nestjs/schedule": {
@@ -3727,7 +3743,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.12.tgz",
       "integrity": "sha512-ulSOYcgosx1TqY425cRC5oXtAu1R10+OSmVfgyR9ueR25k4luekURt8dzAZxhxSCI0OsDj9WKCFLTkEuAwg0wg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -3843,7 +3858,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
       "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -4825,7 +4839,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -4997,7 +5010,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
       "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -5227,7 +5239,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -5918,7 +5929,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5968,7 +5978,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6597,7 +6606,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6676,7 +6684,6 @@
       "resolved": "https://registry.npmjs.org/bull/-/bull-4.16.5.tgz",
       "integrity": "sha512-lDsx2BzkKe7gkCYiT5Acj02DpTwDznl/VNN7Psn7M3USPG7Vs/BaClZJJTAG+ufAR9++N1/NiUTdaFBWDIl5TQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cron-parser": "^4.9.0",
         "get-port": "^5.1.1",
@@ -6724,7 +6731,6 @@
       "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-7.2.8.tgz",
       "integrity": "sha512-0HDaDLBBY/maa/LmUVAr70XUOwsiQD+jyzCBjmUErYZUKdMS9dT59PqW59PpVqfGM7ve6H0J6307JTpkCYefHQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cacheable/utils": "^2.3.3",
         "keyv": "^5.5.5"
@@ -6918,7 +6924,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -6966,15 +6971,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -8217,7 +8220,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8278,7 +8280,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -10144,7 +10145,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -11024,7 +11024,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -12444,7 +12443,6 @@
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.12.tgz",
       "integrity": "sha512-H+rnK5bX2Pi/6ms3sN4/jRQvYSMltV6vqup/0SFOrxYYY/qoNvhXPlYq3e+Pm9RFJRwrMGbMIwi81M4dxpomhA==",
       "license": "MIT-0",
-      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -12877,7 +12875,6 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -13030,7 +13027,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.17.2.tgz",
       "integrity": "sha512-vjbKdiBJRqzcYw1fNU5KuHyYvdJ1qpcQg1CeBrHFqV1pWgHeVR6j/+kX0E1AAXfyuLUGY1ICrN2ELKA/z2HWzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.10.1",
         "pg-pool": "^3.11.0",
@@ -13302,7 +13298,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13872,7 +13867,6 @@
       "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
       "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "./packages/*"
       ],
@@ -14268,7 +14262,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -15546,7 +15539,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15713,7 +15705,6 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
       "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -15877,7 +15868,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16372,7 +16362,6 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,7 @@
     "@nestjs/mapped-types": "*",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.1.12",
+    "@nestjs/platform-socket.io": "^11.1.12",
     "@nestjs/schedule": "^6.1.0",
     "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { OrdersModule } from './modules/orders/orders.module';
 
 @Module({
   imports: [
@@ -33,6 +34,8 @@ import { AppService } from './app.service';
         };
       },
     }),
+
+    OrdersModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -27,6 +27,6 @@ import { Restaurant } from '../restaurant/restaurant.entity';
   ],
   controllers: [AuthController],
   providers: [AuthService, JwtStrategy],
-  exports: [AuthService],
+  exports: [AuthService, JwtModule],
 })
 export class AuthModule {}

--- a/backend/src/modules/orders/dto/create-order-notification.dto.ts
+++ b/backend/src/modules/orders/dto/create-order-notification.dto.ts
@@ -1,0 +1,15 @@
+// backend/src/modules/orders/dto/create-order-notification.dto.ts
+import { IsNumber, IsString, IsOptional, Min } from 'class-validator';
+
+export class CreateOrderNotificationDto {
+  @IsString()
+  orderNumber: string;
+
+  @IsNumber()
+  @Min(0)
+  total: number;
+
+  @IsString()
+  @IsOptional()
+  status?: string;
+}

--- a/backend/src/modules/orders/dto/update-order-status.dto.ts
+++ b/backend/src/modules/orders/dto/update-order-status.dto.ts
@@ -1,0 +1,11 @@
+// backend/src/modules/orders/dto/update-order-status.dto.ts
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdateOrderStatusDto {
+  @IsString()
+  status: string;
+
+  @IsString()
+  @IsOptional()
+  orderNumber?: string;
+}

--- a/backend/src/modules/orders/orders.controller.ts
+++ b/backend/src/modules/orders/orders.controller.ts
@@ -1,0 +1,63 @@
+// backend/src/modules/orders/orders.controller.ts
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { v4 as uuid } from 'uuid';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CreateOrderNotificationDto } from './dto/create-order-notification.dto';
+import { UpdateOrderStatusDto } from './dto/update-order-status.dto';
+import { OrdersGateway } from './orders.gateway';
+
+// There is no persisted Orders domain yet — these endpoints are the
+// integration point real order creation/status-update flows will call into
+// once that domain lands. For now they broadcast directly over the
+// OrdersGateway so the real-time notification path can be built and tested
+// end-to-end ahead of it.
+@Controller('orders')
+@UseGuards(JwtAuthGuard)
+export class OrdersController {
+  constructor(private readonly ordersGateway: OrdersGateway) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(@Request() req, @Body() dto: CreateOrderNotificationDto) {
+    const order = {
+      orderId: uuid(),
+      orderNumber: dto.orderNumber,
+      status: dto.status ?? 'pending',
+      total: dto.total,
+      createdAt: new Date().toISOString(),
+    };
+
+    this.ordersGateway.emitNewOrder(req.user.restaurantId, order);
+
+    return order;
+  }
+
+  @Patch(':orderId/status')
+  @HttpCode(HttpStatus.OK)
+  updateStatus(
+    @Request() req,
+    @Param('orderId') orderId: string,
+    @Body() dto: UpdateOrderStatusDto,
+  ) {
+    const event = {
+      orderId,
+      orderNumber: dto.orderNumber ?? orderId,
+      status: dto.status,
+      updatedAt: new Date().toISOString(),
+    };
+
+    this.ordersGateway.emitOrderStatusChanged(req.user.restaurantId, event);
+
+    return event;
+  }
+}

--- a/backend/src/modules/orders/orders.gateway.ts
+++ b/backend/src/modules/orders/orders.gateway.ts
@@ -1,0 +1,111 @@
+// backend/src/modules/orders/orders.gateway.ts
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import {
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  WebSocketGateway,
+  WebSocketServer,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+
+interface OrderSocketUser {
+  sub: string;
+  username: string;
+  role: string;
+  restaurantId: string;
+}
+
+export interface NewOrderEvent {
+  orderId: string;
+  orderNumber: string;
+  status: string;
+  total: number;
+  createdAt: string;
+}
+
+export interface OrderStatusChangedEvent {
+  orderId: string;
+  orderNumber: string;
+  status: string;
+  updatedAt: string;
+}
+
+function restaurantRoom(restaurantId: string): string {
+  return `restaurant:${restaurantId}`;
+}
+
+// Namespaced so future gateways (e.g. table/reservation updates) don't share
+// this connection's auth handshake or event names.
+@WebSocketGateway({
+  namespace: '/orders',
+  cors: {
+    origin: process.env.FRONTEND_URL || 'http://localhost:3000',
+    credentials: true,
+  },
+})
+export class OrdersGateway implements OnGatewayConnection, OnGatewayDisconnect {
+  private readonly logger = new Logger(OrdersGateway.name);
+
+  @WebSocketServer()
+  server: Server;
+
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  // Guards decorate message handlers, not the initial handshake, so the JWT
+  // is verified here and the socket is dropped immediately if it's missing
+  // or invalid — matching the HTTP JwtAuthGuard's behavior for this domain.
+  handleConnection(client: Socket): void {
+    const token = client.handshake.auth?.token as string | undefined;
+
+    if (!token) {
+      this.rejectConnection(client, 'Missing authentication token');
+      return;
+    }
+
+    try {
+      const payload = this.jwtService.verify<OrderSocketUser>(token, {
+        secret: this.configService.get('JWT_SECRET') || 'your-secret-key',
+      });
+
+      if (!payload.restaurantId) {
+        this.rejectConnection(client, 'Token missing restaurant scope');
+        return;
+      }
+
+      client.data.user = payload;
+      void client.join(restaurantRoom(payload.restaurantId));
+      this.logger.log(
+        `Client ${client.id} connected (restaurant ${payload.restaurantId})`,
+      );
+    } catch {
+      this.rejectConnection(client, 'Invalid or expired token');
+    }
+  }
+
+  handleDisconnect(client: Socket): void {
+    this.logger.log(`Client ${client.id} disconnected`);
+  }
+
+  private rejectConnection(client: Socket, reason: string): void {
+    client.emit('connection:error', { message: reason });
+    client.disconnect(true);
+  }
+
+  emitNewOrder(restaurantId: string, event: NewOrderEvent): void {
+    this.server.to(restaurantRoom(restaurantId)).emit('order:new', event);
+  }
+
+  emitOrderStatusChanged(
+    restaurantId: string,
+    event: OrderStatusChangedEvent,
+  ): void {
+    this.server
+      .to(restaurantRoom(restaurantId))
+      .emit('order:status_changed', event);
+  }
+}

--- a/backend/src/modules/orders/orders.module.ts
+++ b/backend/src/modules/orders/orders.module.ts
@@ -1,0 +1,13 @@
+// backend/src/modules/orders/orders.module.ts
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { OrdersController } from './orders.controller';
+import { OrdersGateway } from './orders.gateway';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [OrdersController],
+  providers: [OrdersGateway],
+  exports: [OrdersGateway],
+})
+export class OrdersModule {}

--- a/frontend/.example.env
+++ b/frontend/.example.env
@@ -3,6 +3,10 @@ NODE_ENV=production
 NEXT_PUBLIC_API_URL=http://localhost:9002/api
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
+# Socket.io base URL (no /api suffix, no namespace) — falls back to
+# NEXT_PUBLIC_API_URL with /api stripped if unset
+NEXT_PUBLIC_SOCKET_URL=http://localhost:9002
+
 # ADD THIS - Unique identifier for this restaurant
 NEXT_PUBLIC_RESTAURANT_ID=fea837a6-9b15-4135-af7c-37e0b5125ccd
 

--- a/frontend/app/admin/layout.tsx
+++ b/frontend/app/admin/layout.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import ProtectedRoute from "@/providers/ProtectedRoute";
+import { AdminSidebar } from "@/components/admin/AdminSidebar";
+import { useOrderNotifications } from "@/hooks/useOrderNotifications";
+
+function AdminShell({ children }: { children: React.ReactNode }) {
+  // Mounted once for the whole /admin section so the notification socket
+  // stays connected across route changes instead of reconnecting per page.
+  useOrderNotifications();
+
+  return (
+    <div className="flex h-full min-h-screen">
+      <AdminSidebar />
+      <div className="flex-1">{children}</div>
+    </div>
+  );
+}
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <ProtectedRoute>
+      <AdminShell>{children}</AdminShell>
+    </ProtectedRoute>
+  );
+}

--- a/frontend/app/admin/orders/[orderId]/page.tsx
+++ b/frontend/app/admin/orders/[orderId]/page.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useNotifications } from "@/lib/store/notificationStore";
+
+export default function OrderDetailPage() {
+  const { orderId } = useParams<{ orderId: string }>();
+  const notifications = useNotifications();
+  const order = notifications.find(
+    (n) => n.orderId === orderId && n.type === "order:new"
+  );
+
+  if (!order) {
+    return (
+      <div className="p-6">
+        <p className="text-sm text-gray-500">
+          Order not found in this session. It may have arrived before this
+          page loaded, or on a previous session.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 p-6">
+      <h1 className="text-2xl font-bold text-gray-900">
+        Order #{order.orderNumber}
+      </h1>
+      <dl className="grid max-w-md grid-cols-2 gap-4 rounded-lg border bg-white p-4">
+        <dt className="text-sm text-gray-500">Status</dt>
+        <dd className="text-sm font-medium capitalize text-gray-900">
+          {order.status}
+        </dd>
+        <dt className="text-sm text-gray-500">Received</dt>
+        <dd className="text-sm font-medium text-gray-900">
+          {new Date(order.createdAt).toLocaleString()}
+        </dd>
+      </dl>
+    </div>
+  );
+}

--- a/frontend/app/admin/orders/page.tsx
+++ b/frontend/app/admin/orders/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { formatDistanceToNow } from "date-fns";
+import {
+  useNotifications,
+  useNotificationActions,
+} from "@/lib/store/notificationStore";
+
+export default function OrdersPage() {
+  const notifications = useNotifications();
+  const { clearUnread } = useNotificationActions();
+
+  // Acceptance criteria: the unread badge clears as soon as the admin
+  // visits this page, regardless of how they got here (badge click, toast,
+  // or direct nav).
+  useEffect(() => {
+    clearUnread();
+  }, [clearUnread]);
+
+  const orders = notifications.filter((n) => n.type === "order:new");
+
+  return (
+    <div className="space-y-6 p-6">
+      <h1 className="text-2xl font-bold text-gray-900">Orders</h1>
+
+      {orders.length === 0 ? (
+        <p className="text-sm text-gray-500">
+          No orders yet. New orders will appear here in real time.
+        </p>
+      ) : (
+        <ul className="divide-y rounded-lg border bg-white" aria-label="Orders">
+          {orders.map((order) => (
+            <li key={order.id}>
+              <Link
+                href={`/admin/orders/${order.orderId}`}
+                className="flex items-center justify-between px-4 py-3 hover:bg-gray-50"
+              >
+                <div>
+                  <p className="font-medium text-gray-900">
+                    Order #{order.orderNumber}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    <time dateTime={order.createdAt}>
+                      {formatDistanceToNow(new Date(order.createdAt), {
+                        addSuffix: true,
+                      })}
+                    </time>
+                  </p>
+                </div>
+                <span className="rounded-full bg-gray-100 px-2 py-1 text-xs font-medium capitalize text-gray-700">
+                  {order.status}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/admin/AdminSidebar.tsx
+++ b/frontend/components/admin/AdminSidebar.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { LayoutDashboard, ShoppingBag, LogOut } from "lucide-react";
+import { useAuthActions } from "@/lib/store/authStore";
+import { useNotificationActions, useUnreadCount } from "@/lib/store/notificationStore";
+import { disconnectSocket } from "@/lib/socket/socketClient";
+
+const NAV_ITEMS = [
+  { label: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
+  { label: "Orders", href: "/admin/orders", icon: ShoppingBag },
+];
+
+export function AdminSidebar() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const unreadCount = useUnreadCount();
+  const { clearAuth } = useAuthActions();
+  const { reset: resetNotifications } = useNotificationActions();
+
+  function handleLogout() {
+    disconnectSocket();
+    resetNotifications();
+    clearAuth();
+    router.push("/login");
+  }
+
+  return (
+    <aside className="flex h-full w-56 shrink-0 flex-col border-r bg-white">
+      <nav className="flex-1 space-y-1 p-3" aria-label="Admin navigation">
+        {NAV_ITEMS.map(({ label, href, icon: Icon }) => {
+          const isActive = pathname === href || pathname.startsWith(`${href}/`);
+          return (
+            <Link
+              key={href}
+              href={href}
+              aria-current={isActive ? "page" : undefined}
+              className={`flex items-center justify-between rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                isActive
+                  ? "bg-blue-50 text-blue-700"
+                  : "text-gray-600 hover:bg-gray-100"
+              }`}
+            >
+              <span className="flex items-center gap-2">
+                <Icon className="h-4 w-4" aria-hidden="true" />
+                {label}
+              </span>
+              {label === "Orders" && unreadCount > 0 && (
+                <span
+                  aria-label={`${unreadCount} unread orders`}
+                  className="inline-flex min-w-[1.25rem] items-center justify-center rounded-full bg-red-600 px-1.5 py-0.5 text-xs font-semibold text-white"
+                >
+                  {unreadCount > 99 ? "99+" : unreadCount}
+                </span>
+              )}
+            </Link>
+          );
+        })}
+      </nav>
+
+      <div className="border-t p-3">
+        <button
+          type="button"
+          onClick={handleLogout}
+          className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100"
+        >
+          <LogOut className="h-4 w-4" aria-hidden="true" />
+          Log out
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/hooks/useOrderNotifications.tsx
+++ b/frontend/hooks/useOrderNotifications.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { useAuthState } from "@/lib/store/authStore";
+import { useNotificationActions } from "@/lib/store/notificationStore";
+import { connectSocket } from "@/lib/socket/socketClient";
+
+interface NewOrderEvent {
+  orderId: string;
+  orderNumber: string;
+  status: string;
+  total: number;
+  createdAt: string;
+}
+
+interface OrderStatusChangedEvent {
+  orderId: string;
+  orderNumber: string;
+  status: string;
+  updatedAt: string;
+}
+
+function NewOrderToastBody({
+  toastId,
+  event,
+  onNavigate,
+}: {
+  toastId: string | number;
+  event: NewOrderEvent;
+  onNavigate: () => void;
+}) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => {
+        onNavigate();
+        toast.dismiss(toastId);
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          onNavigate();
+          toast.dismiss(toastId);
+        }
+      }}
+      className="flex w-full cursor-pointer items-start gap-3 rounded-lg border bg-white p-4 shadow-lg"
+    >
+      <div className="flex-1">
+        <p className="font-semibold text-gray-900">
+          New order #{event.orderNumber}
+        </p>
+        <p className="text-sm text-gray-600">
+          ${event.total.toFixed(2)} · tap to view
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          toast.dismiss(toastId);
+        }}
+        aria-label="Dismiss notification"
+        className="text-gray-400 hover:text-gray-600"
+      >
+        &times;
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Subscribes to order:new / order:status_changed on the /orders socket
+ * namespace for the lifetime of the mounting component (intended to be the
+ * admin layout, so it stays connected across admin route changes). The
+ * underlying socket is only torn down explicitly on logout — see
+ * disconnectSocket() — not on this hook's unmount, so navigating within the
+ * admin section doesn't cause reconnect flicker.
+ */
+export function useOrderNotifications(): void {
+  const router = useRouter();
+  const { token, isAuthenticated, _hasHydrated } = useAuthState();
+  const { addNotification } = useNotificationActions();
+
+  useEffect(() => {
+    if (!_hasHydrated || !isAuthenticated || !token) return;
+
+    const socket = connectSocket(token);
+
+    const handleNewOrder = (event: NewOrderEvent) => {
+      addNotification({
+        id: `${event.orderId}-new-${event.createdAt}`,
+        orderId: event.orderId,
+        orderNumber: event.orderNumber,
+        type: "order:new",
+        status: event.status,
+        message: `New order #${event.orderNumber}`,
+        createdAt: event.createdAt,
+      });
+
+      toast.custom(
+        (toastId) => (
+          <NewOrderToastBody
+            toastId={toastId}
+            event={event}
+            onNavigate={() => router.push(`/admin/orders/${event.orderId}`)}
+          />
+        ),
+        { duration: Infinity }
+      );
+    };
+
+    const handleStatusChanged = (event: OrderStatusChangedEvent) => {
+      toast(`Order #${event.orderNumber} is now ${event.status}`, {
+        action: {
+          label: "View",
+          onClick: () => router.push(`/admin/orders/${event.orderId}`),
+        },
+      });
+    };
+
+    const handleConnectionError = (payload: { message?: string }) => {
+      toast.error(payload?.message ?? "Notification connection rejected");
+    };
+
+    socket.on("order:new", handleNewOrder);
+    socket.on("order:status_changed", handleStatusChanged);
+    socket.on("connection:error", handleConnectionError);
+
+    return () => {
+      socket.off("order:new", handleNewOrder);
+      socket.off("order:status_changed", handleStatusChanged);
+      socket.off("connection:error", handleConnectionError);
+    };
+  }, [_hasHydrated, isAuthenticated, token, addNotification, router]);
+}

--- a/frontend/lib/socket/socketClient.ts
+++ b/frontend/lib/socket/socketClient.ts
@@ -1,0 +1,51 @@
+import { io, Socket } from "socket.io-client";
+
+const SOCKET_URL =
+  process.env.NEXT_PUBLIC_SOCKET_URL ??
+  (process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:9002/api").replace(
+    /\/api\/?$/,
+    ""
+  );
+
+let socket: Socket | null = null;
+
+/**
+ * Opens (or reuses) the singleton connection to the /orders namespace,
+ * authenticated via the JWT passed as handshake auth — the server rejects
+ * the connection in handleConnection if it's missing or invalid.
+ *
+ * Reconnection uses socket.io's built-in backoff (delay doubles up to
+ * reconnectionDelayMax, jittered by randomizationFactor) rather than a
+ * fixed interval, so a flaky connection doesn't hammer the server.
+ */
+export function connectSocket(token: string): Socket {
+  if (socket) {
+    if (socket.auth && (socket.auth as { token?: string }).token === token) {
+      if (!socket.connected) socket.connect();
+      return socket;
+    }
+    socket.disconnect();
+    socket = null;
+  }
+
+  socket = io(`${SOCKET_URL}/orders`, {
+    auth: { token },
+    reconnection: true,
+    reconnectionAttempts: Infinity,
+    reconnectionDelay: 1000,
+    reconnectionDelayMax: 30000,
+    randomizationFactor: 0.5,
+  });
+
+  return socket;
+}
+
+export function getSocket(): Socket | null {
+  return socket;
+}
+
+export function disconnectSocket(): void {
+  if (!socket) return;
+  socket.disconnect();
+  socket = null;
+}

--- a/frontend/lib/store/notificationStore.ts
+++ b/frontend/lib/store/notificationStore.ts
@@ -1,0 +1,58 @@
+import { create } from "zustand";
+
+export interface OrderNotification {
+  id: string;
+  orderId: string;
+  orderNumber: string;
+  type: "order:new" | "order:status_changed";
+  status: string;
+  message: string;
+  createdAt: string;
+  read: boolean;
+}
+
+const MAX_NOTIFICATIONS = 50;
+
+interface NotificationState {
+  notifications: OrderNotification[];
+  unreadCount: number;
+
+  addNotification: (notification: Omit<OrderNotification, "read">) => void;
+  clearUnread: () => void;
+  reset: () => void;
+}
+
+export const useNotificationStore = create<NotificationState>()((set) => ({
+  notifications: [],
+  unreadCount: 0,
+
+  addNotification: (notification) =>
+    set((state) => ({
+      notifications: [
+        { ...notification, read: false },
+        ...state.notifications,
+      ].slice(0, MAX_NOTIFICATIONS),
+      unreadCount: state.unreadCount + 1,
+    })),
+
+  clearUnread: () =>
+    set((state) => ({
+      unreadCount: 0,
+      notifications: state.notifications.map((n) => ({ ...n, read: true })),
+    })),
+
+  reset: () => set({ notifications: [], unreadCount: 0 }),
+}));
+
+export const useUnreadCount = () =>
+  useNotificationStore((state) => state.unreadCount);
+
+export const useNotifications = () =>
+  useNotificationStore((state) => state.notifications);
+
+export const useNotificationActions = () =>
+  useNotificationStore((state) => ({
+    addNotification: state.addNotification,
+    clearUnread: state.clearUnread,
+    reset: state.reset,
+  }));

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1497,7 +1497,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.19.tgz",
       "integrity": "sha512-qTZRZ4QyTzQc+M0IzrbKHxSeISUmRB3RPGmao5bT+sI6ayxSRhn0FXEnT5Hg3as8SBFcRosrXXRFB+yAcxVxJQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.19"
       },
@@ -1670,7 +1669,6 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1736,7 +1734,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -2295,7 +2292,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2765,8 +2761,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -3067,8 +3062,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -3341,7 +3335,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3515,7 +3508,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5301,7 +5293,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
       "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "15.5.9",
         "@swc/helpers": "0.5.15",
@@ -5751,7 +5742,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5761,7 +5751,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -5774,7 +5763,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -5822,15 +5810,13 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5893,8 +5879,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -6159,7 +6144,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -6618,7 +6602,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6768,7 +6751,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
## Summary
- Adds the client-side real-time layer that was missing despite `socket.io-client` sitting unused in `package.json`: a socket connection, event listeners, and notification UI for restaurant admins.
- Adds the matching backend piece, since none existed: an `OrdersGateway` (`/orders` namespace) with JWT handshake auth, emitting `order:new` / `order:status_changed` scoped to a `restaurant:{id}` room.
- Note: this repo has no Orders domain yet (no entity, no create-order flow) and no admin sidebar/login/logout flow existed either — those had to be built as minimal supporting scaffolding rather than assumed to already exist. See "Scope notes" below.

## Backend (`backend/`)
- `src/modules/orders/orders.gateway.ts` — `OrdersGateway`, namespace `/orders`. Verifies the JWT in `handleConnection` (guards don't cover the handshake) and disconnects immediately if it's missing/invalid; joins the socket to `restaurant:{restaurantId}` from the token payload. Exposes `emitNewOrder()` / `emitOrderStatusChanged()` for future callers.
- `src/modules/orders/orders.controller.ts` — `JwtAuthGuard`-protected `POST /orders` and `PATCH /orders/:orderId/status`, which broadcast through the gateway. These stand in for the real order-creation/status-update flow until an Orders domain exists — that integration point is called out in a comment.
- `src/modules/orders/orders.module.ts` — wires the above; imports `AuthModule` for `JwtAuthGuard`/`JwtService`.
- `src/modules/auth/auth.module.ts` — exports `JwtModule` so other modules (namely `OrdersModule`) can inject `JwtService` without re-declaring JWT config.
- `src/app.module.ts` — registers `OrdersModule` (previously no feature modules were imported into `AppModule` at all).
- `package.json` — added `@nestjs/platform-socket.io`, the socket.io adapter `@nestjs/websockets` needs at runtime (was an uninstalled optional peer dep).

## Frontend (`frontend/`)
- `lib/socket/socketClient.ts` — singleton Socket.io client for the `/orders` namespace, JWT passed as `auth: { token }`. Reconnection uses socket.io's built-in exponential backoff (`reconnectionDelay: 1000` → `reconnectionDelayMax: 30000`, jittered).
- `lib/store/notificationStore.ts` — Zustand store (`unreadCount`, `notifications[]`) with `addNotification` / `clearUnread` / `reset`, following the same conventions as the existing `authStore.ts`.
- `hooks/useOrderNotifications.tsx` — subscribes to `order:new` (persistent, clickable toast via `sonner` + pushes to the notification store) and `order:status_changed` (lighter dismissible toast). Clicking a new-order toast navigates to `/admin/orders/{orderId}`.
- `components/admin/AdminSidebar.tsx` — nav with an unread badge on "Orders"; logout button disconnects the socket, resets notifications, and clears auth.
- `app/admin/layout.tsx` — mounts the sidebar + `useOrderNotifications()` once for the whole `/admin` section (wrapped in the existing `ProtectedRoute`), so the socket persists across admin route changes instead of reconnecting per page.
- `app/admin/orders/page.tsx`, `app/admin/orders/[orderId]/page.tsx` — orders list/detail. Visiting the list clears the unread badge.
- `.example.env` — documents `NEXT_PUBLIC_SOCKET_URL` (falls back to `NEXT_PUBLIC_API_URL` with `/api` stripped).

## Acceptance criteria
- [x] New order toast — `order:new` triggers immediately via websocket push, no polling.
- [x] Unread badge increments on each `order:new` (status-change events don't touch the badge, matching the criteria wording).
- [x] Badge clears when the admin visits `/admin/orders`.
- [x] Reconnects automatically with exponential backoff (socket.io default, tuned).
- [x] Connection rejected server-side if the JWT is missing/invalid (`handleConnection` in `OrdersGateway`).
- [x] Socket disconnects on logout (`AdminSidebar.handleLogout`).

## Scope notes / known gaps (pre-existing, not introduced by this PR)
- No Orders domain (entity/service/persistence) exists in the backend. `OrdersController`'s two endpoints exist to make the notification path testable end-to-end and are the intended integration point once real order creation lands.
- The frontend has three different, disconnected token stores (`authStore` via Zustand/localStorage, a separate `localStorage["auth-token"]` read by `apiClient`, and an `accessToken` cookie read by `middleware.ts`), and no login page wires any of them yet. The socket client uses `authStore`'s token, consistent with `ProtectedRoute`, but reconciling all three is a separate, larger fix.
- No admin sidebar, `/admin` layout, or logout flow existed before this PR — added the minimal versions needed to host the Orders nav item/badge per the acceptance criteria.

## Test plan
- [x] `cd backend && npm run build` — compiles clean.
- [x] `cd backend && npm run lint` — clean.
- [x] `cd frontend && npx tsc --noEmit` — no type errors.
- [x] `cd frontend && npm run lint` — clean.
- [ ] Manual: log in as an admin, trigger `POST /orders`, confirm toast appears <1s and badge increments; click toast, confirm navigation to `/admin/orders/{orderId}`; visit `/admin/orders`, confirm badge clears; kill/restart the backend, confirm the socket reconnects; log out, confirm the socket disconnects (no further events received).

## Issue
Closes #277 
