### PR TITLE
feat(payments): persisted order/payment schema, Stellar service layer, and custody model decision

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -33,3 +33,8 @@ ADMIN_DEFAULT_USERNAME=admin
 ADMIN_DEFAULT_EMAIL=admin@restaurant.com
 ADMIN_DEFAULT_PASSWORD=changeme123
 
+# Stellar (see docs/adr/0001-payment-custody-model.md)
+# StellarService fails fast at boot if these are missing.
+STELLAR_NETWORK=testnet
+STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -51,7 +51,6 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
         "socket.io": "^4.8.3",
-        "stellar-sdk": "^13.3.0",
         "typeorm": "^0.3.28",
         "ua-parser-js": "^2.0.8",
         "uuid": "^13.0.0"
@@ -72,7 +71,6 @@
         "@types/nodemailer": "^7.0.5",
         "@types/passport-jwt": "^4.0.1",
         "@types/passport-local": "^1.0.38",
-        "@types/stellar-sdk": "^0.15.1",
         "@types/supertest": "^6.0.3",
         "@types/ua-parser-js": "^0.7.39",
         "@typescript-eslint/eslint-plugin": "^8.53.1",
@@ -1069,6 +1067,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -3434,6 +3433,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.12.tgz",
       "integrity": "sha512-v6U3O01YohHO+IE3EIFXuRuu3VJILWzyMmSYZXpyBbnp0hk0mFyHxK2w3dF4I5WnbwiRbWlEXdeXFvPQ7qaZzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -3481,6 +3481,7 @@
       "integrity": "sha512-97DzTYMf5RtGAVvX1cjwpKRiCUpkeQ9CCzSAenqkAhOmNVVFaApbhuw+xrDt13rsCa2hHVOYPrV4dBgOYMJjsA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -3564,6 +3565,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.12.tgz",
       "integrity": "sha512-GYK/vHI0SGz5m8mxr7v3Urx8b9t78Cf/dj5aJMZlGd9/1D9OI1hAl00BaphjEXINUJ/BQLxIlF2zUjrYsd6enQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.2.1",
@@ -3585,6 +3587,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.28.tgz",
       "integrity": "sha512-vY+GmU2jBcymvgm5rEnftUx4qNxK8cDJmXjl1/1NcpITTNJo0vg07xYR43MwXHcMqe7b0jwqt5+UCTzxqQFIqA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "socket.io": "4.8.3",
         "tslib": "2.8.1"
@@ -3743,6 +3746,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.12.tgz",
       "integrity": "sha512-ulSOYcgosx1TqY425cRC5oXtAu1R10+OSmVfgyR9ueR25k4luekURt8dzAZxhxSCI0OsDj9WKCFLTkEuAwg0wg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -3858,6 +3862,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
       "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -4839,6 +4844,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -5010,6 +5016,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
       "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -5139,17 +5146,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/stellar-sdk": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@types/stellar-sdk/-/stellar-sdk-0.15.1.tgz",
-      "integrity": "sha512-PE3Sj1alFUR32NjoR6C7DEusVaqokcQ8DOnq+c5/DoBDDzJrGXjui/3HLYgsQZIy7uabBJczGapuweWAGWPbmQ==",
-      "deprecated": "This is a stub types definition. stellar-sdk provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "stellar-sdk": "*"
-      }
-    },
     "node_modules/@types/superagent": {
       "version": "8.1.9",
       "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
@@ -5239,6 +5235,7 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -5929,6 +5926,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5978,6 +5976,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6352,50 +6351,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
-    "node_modules/bare-addon-resolve": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.9.6.tgz",
-      "integrity": "sha512-hvOQY1zDK6u0rSr27T6QlULoVLwi8J2k8HHHJlxSfT7XQdQ/7bsS+AnjYkHtu/TkL+gm3aMXAKucJkJAbrDG/g==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-module-resolve": "^1.10.0",
-        "bare-semver": "^1.0.0"
-      },
-      "peerDependencies": {
-        "bare-url": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-url": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-module-resolve": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.1.tgz",
-      "integrity": "sha512-hbmAPyFpEq8FoZMd5sFO3u6MC5feluWoGE8YKlA8fCrl6mNtx68Wjg4DTiDJcqRJaovTvOYKfYngoBUnbaT7eg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-semver": "^1.0.0"
-      },
-      "peerDependencies": {
-        "bare-url": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-url": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-semver": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.0.2.tgz",
-      "integrity": "sha512-ESVaN2nzWhcI5tf3Zzcq9aqCZ676VWzqw07eEZ0qxAcEOAFYBa0pWq8sK34OQeHLY3JsfKXZS9mDyzyxGjeLzA==",
-      "license": "Apache-2.0",
-      "optional": true
-    },
     "node_modules/base32.js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
@@ -6606,6 +6561,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6684,6 +6640,7 @@
       "resolved": "https://registry.npmjs.org/bull/-/bull-4.16.5.tgz",
       "integrity": "sha512-lDsx2BzkKe7gkCYiT5Acj02DpTwDznl/VNN7Psn7M3USPG7Vs/BaClZJJTAG+ufAR9++N1/NiUTdaFBWDIl5TQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cron-parser": "^4.9.0",
         "get-port": "^5.1.1",
@@ -6731,6 +6688,7 @@
       "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-7.2.8.tgz",
       "integrity": "sha512-0HDaDLBBY/maa/LmUVAr70XUOwsiQD+jyzCBjmUErYZUKdMS9dT59PqW59PpVqfGM7ve6H0J6307JTpkCYefHQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cacheable/utils": "^2.3.3",
         "keyv": "^5.5.5"
@@ -6924,6 +6882,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -6971,13 +6930,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -8220,6 +8181,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8280,6 +8242,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -10145,6 +10108,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -11024,6 +10988,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -12443,6 +12408,7 @@
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.12.tgz",
       "integrity": "sha512-H+rnK5bX2Pi/6ms3sN4/jRQvYSMltV6vqup/0SFOrxYYY/qoNvhXPlYq3e+Pm9RFJRwrMGbMIwi81M4dxpomhA==",
       "license": "MIT-0",
+      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -12875,6 +12841,7 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -13027,6 +12994,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.17.2.tgz",
       "integrity": "sha512-vjbKdiBJRqzcYw1fNU5KuHyYvdJ1qpcQg1CeBrHFqV1pWgHeVR6j/+kX0E1AAXfyuLUGY1ICrN2ELKA/z2HWzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.10.1",
         "pg-pool": "^3.11.0",
@@ -13298,6 +13266,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13867,6 +13836,7 @@
       "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
       "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "./packages/*"
       ],
@@ -13914,19 +13884,6 @@
       "optional": true,
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/require-addon": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/require-addon/-/require-addon-1.2.0.tgz",
-      "integrity": "sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-addon-resolve": "^1.3.0"
-      },
-      "engines": {
-        "bare": ">=1.10.0"
       }
     },
     "node_modules/require-directory": {
@@ -14262,6 +14219,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -14628,16 +14586,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/sodium-native": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.3.tgz",
-      "integrity": "sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "require-addon": "^1.1.0"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -14737,46 +14685,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/stellar-sdk": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/stellar-sdk/-/stellar-sdk-13.3.0.tgz",
-      "integrity": "sha512-jAA3+U7oAUueldoS4kuEhcym+DigElWq9isPxt7tjMrE7kTJ2vvY29waavUb2FSfQIWwGbuwAJTYddy2BeyJsw==",
-      "deprecated": "⚠️ This package has moved to @stellar/stellar-sdk! 🚚",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/stellar-base": "^13.1.0",
-        "axios": "^1.8.4",
-        "bignumber.js": "^9.3.0",
-        "eventsource": "^2.0.2",
-        "feaxios": "^0.0.23",
-        "randombytes": "^2.1.0",
-        "toml": "^3.0.0",
-        "urijs": "^1.19.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/stellar-sdk/node_modules/@stellar/stellar-base": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-13.1.0.tgz",
-      "integrity": "sha512-90EArG+eCCEzDGj3OJNoCtwpWDwxjv+rs/RNPhvg4bulpjN/CSRj+Ys/SalRcfM4/WRC5/qAfjzmJBAuquWhkA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/js-xdr": "^3.1.2",
-        "base32.js": "^0.1.0",
-        "bignumber.js": "^9.1.2",
-        "buffer": "^6.0.3",
-        "sha.js": "^2.3.6",
-        "tweetnacl": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "sodium-native": "^4.3.3"
       }
     },
     "node_modules/streamsearch": {
@@ -15539,6 +15447,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15624,12 +15533,6 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
-    "node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "license": "Unlicense"
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -15705,6 +15608,7 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
       "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -15868,6 +15772,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16362,6 +16267,7 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/backend/package.json
+++ b/backend/package.json
@@ -62,7 +62,6 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "socket.io": "^4.8.3",
-    "stellar-sdk": "^13.3.0",
     "typeorm": "^0.3.28",
     "ua-parser-js": "^2.0.8",
     "uuid": "^13.0.0"
@@ -83,7 +82,6 @@
     "@types/nodemailer": "^7.0.5",
     "@types/passport-jwt": "^4.0.1",
     "@types/passport-local": "^1.0.38",
-    "@types/stellar-sdk": "^0.15.1",
     "@types/supertest": "^6.0.3",
     "@types/ua-parser-js": "^0.7.39",
     "@typescript-eslint/eslint-plugin": "^8.53.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { AppService } from './app.service';
 import { OrdersModule } from './modules/orders/orders.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { AdminModule } from './modules/admin/admin.module';
+import { PaymentsModule } from './modules/payments/payments.module';
 import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
 import { RolesGuard } from './common/guards/roles.guard';
 
@@ -53,6 +54,7 @@ import { RolesGuard } from './common/guards/roles.guard';
     OrdersModule,
     AuthModule,
     AdminModule,
+    PaymentsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/modules/orders/dto/create-order-notification.dto.ts
+++ b/backend/src/modules/orders/dto/create-order-notification.dto.ts
@@ -1,5 +1,6 @@
 // backend/src/modules/orders/dto/create-order-notification.dto.ts
-import { IsNumber, IsString, IsOptional, Min } from 'class-validator';
+import { IsEnum, IsNumber, IsString, IsOptional, Min } from 'class-validator';
+import { OrderStatus } from '../order.entity';
 
 export class CreateOrderNotificationDto {
   @IsString()
@@ -9,7 +10,7 @@ export class CreateOrderNotificationDto {
   @Min(0)
   total: number;
 
-  @IsString()
+  @IsEnum(OrderStatus)
   @IsOptional()
-  status?: string;
+  status?: OrderStatus;
 }

--- a/backend/src/modules/orders/dto/update-order-status.dto.ts
+++ b/backend/src/modules/orders/dto/update-order-status.dto.ts
@@ -1,9 +1,10 @@
 // backend/src/modules/orders/dto/update-order-status.dto.ts
-import { IsOptional, IsString } from 'class-validator';
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { OrderStatus } from '../order.entity';
 
 export class UpdateOrderStatusDto {
-  @IsString()
-  status: string;
+  @IsEnum(OrderStatus)
+  status: OrderStatus;
 
   @IsString()
   @IsOptional()

--- a/backend/src/modules/orders/order.entity.ts
+++ b/backend/src/modules/orders/order.entity.ts
@@ -1,0 +1,68 @@
+// backend/src/modules/orders/order.entity.ts
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Restaurant } from '../restaurant/restaurant.entity';
+
+export enum OrderStatus {
+  PENDING = 'pending',
+  CONFIRMED = 'confirmed',
+  PREPARING = 'preparing',
+  READY = 'ready',
+  COMPLETED = 'completed',
+  CANCELLED = 'cancelled',
+}
+
+// Line items are stored as jsonb rather than a child table for now — the
+// real order-creation flow (with a validated cart/menu-item linkage) is a
+// later issue in this batch; this shape is a placeholder good enough to
+// persist what the current notification-only endpoints already collect.
+export interface OrderLineItem {
+  name: string;
+  quantity: number;
+  price: number;
+}
+
+@Entity('orders')
+export class Order {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 100 })
+  orderNumber: string;
+
+  @Column({ type: 'uuid' })
+  restaurantId: string;
+
+  @ManyToOne(() => Restaurant, (restaurant) => restaurant.orders, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'restaurantId' })
+  restaurant: Restaurant;
+
+  @Column({ type: 'jsonb', default: () => "'[]'" })
+  items: OrderLineItem[];
+
+  @Column({ type: 'decimal', precision: 12, scale: 2 })
+  total: number;
+
+  // Settlement asset code (e.g. XLM, USDC) — matches the asset the diner
+  // pays with via StellarCheckout, not a fiat currency.
+  @Column({ type: 'varchar', length: 10, default: 'XLM' })
+  currency: string;
+
+  @Column({ type: 'enum', enum: OrderStatus, default: OrderStatus.PENDING })
+  status: OrderStatus;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/modules/orders/orders.controller.ts
+++ b/backend/src/modules/orders/orders.controller.ts
@@ -10,31 +10,31 @@ import {
   Request,
   UseGuards,
 } from '@nestjs/common';
-import { v4 as uuid } from 'uuid';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { CreateOrderNotificationDto } from './dto/create-order-notification.dto';
 import { UpdateOrderStatusDto } from './dto/update-order-status.dto';
 import { OrdersGateway } from './orders.gateway';
+import { OrdersService } from './orders.service';
 
-// There is no persisted Orders domain yet — these endpoints are the
-// integration point real order creation/status-update flows will call into
-// once that domain lands. For now they broadcast directly over the
-// OrdersGateway so the real-time notification path can be built and tested
-// end-to-end ahead of it.
 @Controller('orders')
 @UseGuards(JwtAuthGuard)
 export class OrdersController {
-  constructor(private readonly ordersGateway: OrdersGateway) {}
+  constructor(
+    private readonly ordersGateway: OrdersGateway,
+    private readonly ordersService: OrdersService,
+  ) {}
 
   @Post()
   @HttpCode(HttpStatus.CREATED)
-  create(@Request() req, @Body() dto: CreateOrderNotificationDto) {
+  async create(@Request() req, @Body() dto: CreateOrderNotificationDto) {
+    const saved = await this.ordersService.create(req.user.restaurantId, dto);
+
     const order = {
-      orderId: uuid(),
-      orderNumber: dto.orderNumber,
-      status: dto.status ?? 'pending',
-      total: dto.total,
-      createdAt: new Date().toISOString(),
+      orderId: saved.id,
+      orderNumber: saved.orderNumber,
+      status: saved.status,
+      total: Number(saved.total),
+      createdAt: saved.createdAt.toISOString(),
     };
 
     this.ordersGateway.emitNewOrder(req.user.restaurantId, order);
@@ -44,16 +44,22 @@ export class OrdersController {
 
   @Patch(':orderId/status')
   @HttpCode(HttpStatus.OK)
-  updateStatus(
+  async updateStatus(
     @Request() req,
     @Param('orderId') orderId: string,
     @Body() dto: UpdateOrderStatusDto,
   ) {
-    const event = {
+    const saved = await this.ordersService.updateStatus(
       orderId,
-      orderNumber: dto.orderNumber ?? orderId,
-      status: dto.status,
-      updatedAt: new Date().toISOString(),
+      req.user.restaurantId,
+      dto,
+    );
+
+    const event = {
+      orderId: saved.id,
+      orderNumber: dto.orderNumber ?? saved.orderNumber,
+      status: saved.status,
+      updatedAt: saved.updatedAt.toISOString(),
     };
 
     this.ordersGateway.emitOrderStatusChanged(req.user.restaurantId, event);

--- a/backend/src/modules/orders/orders.module.ts
+++ b/backend/src/modules/orders/orders.module.ts
@@ -1,13 +1,16 @@
 // backend/src/modules/orders/orders.module.ts
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
+import { Order } from './order.entity';
 import { OrdersController } from './orders.controller';
 import { OrdersGateway } from './orders.gateway';
+import { OrdersService } from './orders.service';
 
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, TypeOrmModule.forFeature([Order])],
   controllers: [OrdersController],
-  providers: [OrdersGateway],
-  exports: [OrdersGateway],
+  providers: [OrdersGateway, OrdersService],
+  exports: [OrdersGateway, OrdersService],
 })
 export class OrdersModule {}

--- a/backend/src/modules/orders/orders.service.spec.ts
+++ b/backend/src/modules/orders/orders.service.spec.ts
@@ -1,0 +1,107 @@
+import { NotFoundException } from '@nestjs/common';
+import { OrdersService } from './orders.service';
+import { OrderStatus } from './order.entity';
+
+type MockRepository = {
+  create: jest.Mock;
+  save: jest.Mock;
+  findOne: jest.Mock;
+};
+
+function makeRepository(): MockRepository {
+  return {
+    create: jest.fn((data) => ({ ...data })),
+    save: jest.fn(async (entity) => ({
+      id: entity.id ?? 'generated-id',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      ...entity,
+    })),
+    findOne: jest.fn(),
+  };
+}
+
+describe('OrdersService', () => {
+  let repository: MockRepository;
+  let service: OrdersService;
+
+  beforeEach(() => {
+    repository = makeRepository();
+    service = new OrdersService(repository as any);
+  });
+
+  describe('create', () => {
+    it('persists the order with sensible defaults for fields the notification DTO does not collect yet', async () => {
+      const order = await service.create('restaurant-1', {
+        orderNumber: 'ORD-1',
+        total: 42.5,
+      });
+
+      expect(repository.create).toHaveBeenCalledWith({
+        orderNumber: 'ORD-1',
+        restaurantId: 'restaurant-1',
+        total: 42.5,
+        status: OrderStatus.PENDING,
+        items: [],
+        currency: 'XLM',
+      });
+      expect(order.id).toBe('generated-id');
+    });
+
+    it('honors an explicit status when provided', async () => {
+      const order = await service.create('restaurant-1', {
+        orderNumber: 'ORD-2',
+        total: 10,
+        status: OrderStatus.CONFIRMED,
+      });
+
+      expect(order.status).toBe(OrderStatus.CONFIRMED);
+    });
+  });
+
+  describe('updateStatus', () => {
+    it('throws NotFoundException when the order does not exist for this restaurant', async () => {
+      repository.findOne.mockResolvedValueOnce(null);
+
+      await expect(
+        service.updateStatus('missing-id', 'restaurant-1', {
+          status: OrderStatus.CONFIRMED,
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('updates and persists the new status', async () => {
+      repository.findOne.mockResolvedValueOnce({
+        id: 'order-1',
+        restaurantId: 'restaurant-1',
+        orderNumber: 'ORD-1',
+        status: OrderStatus.PENDING,
+      });
+
+      const result = await service.updateStatus('order-1', 'restaurant-1', {
+        status: OrderStatus.PREPARING,
+      });
+
+      expect(result.status).toBe(OrderStatus.PREPARING);
+      expect(repository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: OrderStatus.PREPARING }),
+      );
+    });
+
+    it('scopes the lookup to the requesting restaurant', async () => {
+      repository.findOne.mockResolvedValueOnce({
+        id: 'order-1',
+        restaurantId: 'restaurant-1',
+        status: OrderStatus.PENDING,
+      });
+
+      await service.updateStatus('order-1', 'restaurant-1', {
+        status: OrderStatus.CONFIRMED,
+      });
+
+      expect(repository.findOne).toHaveBeenCalledWith({
+        where: { id: 'order-1', restaurantId: 'restaurant-1' },
+      });
+    });
+  });
+});

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -1,0 +1,53 @@
+// backend/src/modules/orders/orders.service.ts
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Order, OrderStatus } from './order.entity';
+import { CreateOrderNotificationDto } from './dto/create-order-notification.dto';
+import { UpdateOrderStatusDto } from './dto/update-order-status.dto';
+
+@Injectable()
+export class OrdersService {
+  constructor(
+    @InjectRepository(Order)
+    private readonly orderRepository: Repository<Order>,
+  ) {}
+
+  // The current notification-only DTO doesn't yet collect line items or a
+  // settlement asset — the real order-creation flow (with a validated
+  // cart/menu-item linkage) is a later issue in this batch. This persists
+  // what's available today with sensible defaults for the rest, so the
+  // Order table exists and later issues can extend it in place.
+  async create(
+    restaurantId: string,
+    dto: CreateOrderNotificationDto,
+  ): Promise<Order> {
+    const order = this.orderRepository.create({
+      orderNumber: dto.orderNumber,
+      restaurantId,
+      total: dto.total,
+      status: dto.status ?? OrderStatus.PENDING,
+      items: [],
+      currency: 'XLM',
+    });
+
+    return this.orderRepository.save(order);
+  }
+
+  async updateStatus(
+    orderId: string,
+    restaurantId: string,
+    dto: UpdateOrderStatusDto,
+  ): Promise<Order> {
+    const order = await this.orderRepository.findOne({
+      where: { id: orderId, restaurantId },
+    });
+
+    if (!order) {
+      throw new NotFoundException(`Order ${orderId} not found`);
+    }
+
+    order.status = dto.status;
+    return this.orderRepository.save(order);
+  }
+}

--- a/backend/src/modules/payments/payment.entity.ts
+++ b/backend/src/modules/payments/payment.entity.ts
@@ -1,0 +1,72 @@
+// backend/src/modules/payments/payment.entity.ts
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Order } from '../orders/order.entity';
+
+export enum PaymentStatus {
+  PENDING = 'pending',
+  SUBMITTED = 'submitted',
+  CONFIRMED = 'confirmed',
+  FAILED = 'failed',
+  EXPIRED = 'expired',
+}
+
+@Entity('payments')
+export class Payment {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  orderId: string;
+
+  @ManyToOne(() => Order, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'orderId' })
+  order: Order;
+
+  // Last line of defense against duplicate charges — enforced at the DB
+  // constraint level, not just in application logic (issue #312 edge case).
+  @Column({ type: 'varchar', length: 255, unique: true })
+  idempotencyKey: string;
+
+  @Column({ type: 'varchar', length: 56 })
+  sourceAccount: string;
+
+  @Column({ type: 'varchar', length: 56 })
+  destinationAccount: string;
+
+  @Column({ type: 'varchar', length: 12 })
+  asset: string;
+
+  @Column({ type: 'decimal', precision: 20, scale: 7 })
+  amount: number;
+
+  @Column({
+    type: 'enum',
+    enum: PaymentStatus,
+    default: PaymentStatus.PENDING,
+  })
+  status: PaymentStatus;
+
+  // Null until the transaction has actually been submitted to Horizon.
+  @Column({ type: 'varchar', length: 64, nullable: true })
+  stellarTxHash: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  horizonEnvelopeXdr: string | null;
+
+  @Column({ type: 'timestamp', nullable: true })
+  confirmedAt: Date | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/modules/payments/payments.module.ts
+++ b/backend/src/modules/payments/payments.module.ts
@@ -1,0 +1,15 @@
+// backend/src/modules/payments/payments.module.ts
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Payment } from './payment.entity';
+import { StellarService } from './stellar.service';
+
+// No HTTP endpoints yet — this issue only establishes the persisted
+// schema and the Stellar service scaffolding. Payment initiation
+// endpoints and business logic land in the next issue of this batch.
+@Module({
+  imports: [TypeOrmModule.forFeature([Payment])],
+  providers: [StellarService],
+  exports: [StellarService],
+})
+export class PaymentsModule {}

--- a/backend/src/modules/payments/stellar.service.integration.spec.ts
+++ b/backend/src/modules/payments/stellar.service.integration.spec.ts
@@ -1,0 +1,40 @@
+// Real-network integration test: loads a freshly-funded testnet account
+// through StellarService and reads its balances against the actual Horizon
+// testnet (issue #312 acceptance criterion). This makes a live network call
+// and is NOT part of the fast, hermetic unit suite CI gates on — it only
+// runs when explicitly opted into, e.g.:
+//
+//   RUN_STELLAR_INTEGRATION_TESTS=true npm run test -- stellar.service.integration
+//
+import { Keypair } from '@stellar/stellar-sdk';
+import { ConfigService } from '@nestjs/config';
+import { StellarService } from './stellar.service';
+
+const runIntegration = process.env.RUN_STELLAR_INTEGRATION_TESTS === 'true';
+const describeIfEnabled = runIntegration ? describe : describe.skip;
+
+describeIfEnabled('StellarService (real Horizon testnet)', () => {
+  jest.setTimeout(30_000);
+
+  it('loads a freshly-funded testnet account and reads its balances', async () => {
+    const config = new ConfigService({
+      STELLAR_HORIZON_URL: 'https://horizon-testnet.stellar.org',
+      STELLAR_NETWORK: 'testnet',
+    });
+    const service = new StellarService(config);
+    service.onModuleInit();
+
+    const keypair = Keypair.random();
+
+    const friendbotResponse = await fetch(
+      `https://friendbot.stellar.org/?addr=${encodeURIComponent(keypair.publicKey())}`,
+    );
+    expect(friendbotResponse.ok).toBe(true);
+
+    const account = await service.loadAccount(keypair.publicKey());
+
+    expect(account.accountId()).toBe(keypair.publicKey());
+    expect(account.balances.length).toBeGreaterThan(0);
+    expect(account.balances.some((b) => b.asset_type === 'native')).toBe(true);
+  });
+});

--- a/backend/src/modules/payments/stellar.service.spec.ts
+++ b/backend/src/modules/payments/stellar.service.spec.ts
@@ -1,0 +1,181 @@
+import { Account, Keypair, Networks } from '@stellar/stellar-sdk';
+import { StellarService } from './stellar.service';
+
+// Real, validly-checksummed keys generated at test time — hand-typed
+// StrKey addresses are easy to get subtly wrong (invalid checksum).
+const sourceKeypair = Keypair.random();
+const destinationKeypair = Keypair.random();
+
+const mockLoadAccount = jest.fn();
+const mockFetchBaseFee = jest.fn();
+const mockSubmitTransaction = jest.fn();
+
+jest.mock('@stellar/stellar-sdk', () => {
+  const actual = jest.requireActual('@stellar/stellar-sdk');
+  return {
+    ...actual,
+    Horizon: {
+      ...actual.Horizon,
+      Server: jest.fn().mockImplementation(() => ({
+        loadAccount: mockLoadAccount,
+        fetchBaseFee: mockFetchBaseFee,
+        submitTransaction: mockSubmitTransaction,
+      })),
+    },
+  };
+});
+
+function makeConfigService(values: Record<string, string | undefined>) {
+  return { get: jest.fn((key: string) => values[key]) };
+}
+
+function readyService(): StellarService {
+  const service = new StellarService(
+    makeConfigService({
+      STELLAR_HORIZON_URL: 'https://horizon-testnet.stellar.org',
+      STELLAR_NETWORK: 'testnet',
+    }) as any,
+  );
+  service.onModuleInit();
+  return service;
+}
+
+describe('StellarService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('onModuleInit', () => {
+    it('throws when STELLAR_HORIZON_URL is missing', () => {
+      const service = new StellarService(
+        makeConfigService({ STELLAR_NETWORK: 'testnet' }) as any,
+      );
+      expect(() => service.onModuleInit()).toThrow(
+        /STELLAR_HORIZON_URL is not configured/,
+      );
+    });
+
+    it('throws when STELLAR_NETWORK is missing', () => {
+      const service = new StellarService(
+        makeConfigService({
+          STELLAR_HORIZON_URL: 'https://horizon-testnet.stellar.org',
+        }) as any,
+      );
+      expect(() => service.onModuleInit()).toThrow(
+        /STELLAR_NETWORK is not configured/,
+      );
+    });
+
+    it('throws when STELLAR_NETWORK is not a recognized value', () => {
+      const service = new StellarService(
+        makeConfigService({
+          STELLAR_HORIZON_URL: 'https://horizon-testnet.stellar.org',
+          STELLAR_NETWORK: 'not-a-real-network',
+        }) as any,
+      );
+      expect(() => service.onModuleInit()).toThrow(
+        /unrecognized STELLAR_NETWORK/,
+      );
+    });
+
+    it('resolves the testnet passphrase and becomes ready', () => {
+      const service = readyService();
+      expect(service.getNetworkPassphrase()).toBe(Networks.TESTNET);
+    });
+
+    it('resolves the mainnet passphrase for "public"', () => {
+      const service = new StellarService(
+        makeConfigService({
+          STELLAR_HORIZON_URL: 'https://horizon.stellar.org',
+          STELLAR_NETWORK: 'public',
+        }) as any,
+      );
+      service.onModuleInit();
+      expect(service.getNetworkPassphrase()).toBe(Networks.PUBLIC);
+    });
+  });
+
+  describe('loadAccount', () => {
+    it('delegates to the Horizon server', async () => {
+      const service = readyService();
+      const fakeAccount = new Account(sourceKeypair.publicKey(), '1');
+      mockLoadAccount.mockResolvedValueOnce(fakeAccount);
+
+      const result = await service.loadAccount(sourceKeypair.publicKey());
+
+      expect(mockLoadAccount).toHaveBeenCalledWith(sourceKeypair.publicKey());
+      expect(result).toBe(fakeAccount);
+    });
+  });
+
+  describe('buildPaymentTransaction', () => {
+    it('builds a signable XDR envelope for a native XLM payment', async () => {
+      const service = readyService();
+
+      mockLoadAccount.mockResolvedValueOnce(
+        new Account(sourceKeypair.publicKey(), '100'),
+      );
+      mockFetchBaseFee.mockResolvedValueOnce(100);
+
+      const xdr = await service.buildPaymentTransaction({
+        sourceAccount: sourceKeypair.publicKey(),
+        destinationAccount: destinationKeypair.publicKey(),
+        assetCode: 'XLM',
+        amount: '10.5000000',
+      });
+
+      expect(typeof xdr).toBe('string');
+      expect(xdr.length).toBeGreaterThan(0);
+      expect(mockFetchBaseFee).toHaveBeenCalled();
+    });
+
+    it('builds a payment for a non-native asset given an issuer', async () => {
+      const service = readyService();
+
+      mockLoadAccount.mockResolvedValueOnce(
+        new Account(sourceKeypair.publicKey(), '100'),
+      );
+      mockFetchBaseFee.mockResolvedValueOnce(100);
+
+      const issuer = Keypair.random().publicKey();
+      const xdr = await service.buildPaymentTransaction({
+        sourceAccount: sourceKeypair.publicKey(),
+        destinationAccount: destinationKeypair.publicKey(),
+        assetCode: 'USDC',
+        assetIssuer: issuer,
+        amount: '5.0000000',
+      });
+
+      expect(typeof xdr).toBe('string');
+      expect(xdr.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('submitTransaction', () => {
+    it('parses the signed XDR and submits it to Horizon', async () => {
+      const service = readyService();
+
+      mockLoadAccount.mockResolvedValueOnce(
+        new Account(sourceKeypair.publicKey(), '100'),
+      );
+      mockFetchBaseFee.mockResolvedValueOnce(100);
+
+      const xdr = await service.buildPaymentTransaction({
+        sourceAccount: sourceKeypair.publicKey(),
+        destinationAccount: destinationKeypair.publicKey(),
+        assetCode: 'XLM',
+        amount: '1.0000000',
+      });
+
+      mockSubmitTransaction.mockResolvedValueOnce({
+        hash: 'fake-hash',
+        successful: true,
+      });
+
+      const result = await service.submitTransaction(xdr);
+
+      expect(mockSubmitTransaction).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ hash: 'fake-hash', successful: true });
+    });
+  });
+});

--- a/backend/src/modules/payments/stellar.service.ts
+++ b/backend/src/modules/payments/stellar.service.ts
@@ -1,0 +1,126 @@
+// backend/src/modules/payments/stellar.service.ts
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  Asset,
+  Horizon,
+  Memo,
+  Networks,
+  Operation,
+  TransactionBuilder,
+} from '@stellar/stellar-sdk';
+
+export interface BuildPaymentTransactionParams {
+  sourceAccount: string;
+  destinationAccount: string;
+  /** 'XLM' for the native asset, otherwise a Stellar asset code (e.g. 'USDC'). */
+  assetCode: string;
+  /** Required unless assetCode === 'XLM'. */
+  assetIssuer?: string;
+  /** Decimal string, e.g. "12.5000000" — never a float, to avoid precision loss. */
+  amount: string;
+  memo?: string;
+}
+
+/**
+ * Thin, testable wrapper around @stellar/stellar-sdk's Horizon.Server.
+ * No business logic lives here (idempotency, persistence, retry policy) —
+ * that's the next issue in the payment track. This issue only needs the
+ * shape: load an account, build an unsigned payment transaction, submit an
+ * already-signed one.
+ */
+@Injectable()
+export class StellarService implements OnModuleInit {
+  private readonly logger = new Logger(StellarService.name);
+  private server: Horizon.Server;
+  private networkPassphrase: string;
+
+  constructor(private readonly configService: ConfigService) {}
+
+  // Fail fast at boot rather than on first payment attempt — a missing or
+  // mismatched Horizon/network config should never surface only when a
+  // diner tries to pay (issue #312 edge case).
+  onModuleInit(): void {
+    const horizonUrl = this.configService.get<string>('STELLAR_HORIZON_URL');
+    const network = this.configService.get<string>('STELLAR_NETWORK');
+
+    if (!horizonUrl) {
+      throw new Error('StellarService: STELLAR_HORIZON_URL is not configured');
+    }
+    if (!network) {
+      throw new Error('StellarService: STELLAR_NETWORK is not configured');
+    }
+
+    this.networkPassphrase = StellarService.resolveNetworkPassphrase(network);
+    this.server = new Horizon.Server(horizonUrl);
+
+    this.logger.log(
+      `Stellar service ready (network=${network}, horizon=${horizonUrl})`,
+    );
+  }
+
+  private static resolveNetworkPassphrase(network: string): string {
+    switch (network.toLowerCase()) {
+      case 'public':
+      case 'mainnet':
+        return Networks.PUBLIC;
+      case 'testnet':
+        return Networks.TESTNET;
+      case 'futurenet':
+        return Networks.FUTURENET;
+      default:
+        throw new Error(
+          `StellarService: unrecognized STELLAR_NETWORK "${network}" ` +
+            '(expected one of: public, mainnet, testnet, futurenet)',
+        );
+    }
+  }
+
+  getNetworkPassphrase(): string {
+    return this.networkPassphrase;
+  }
+
+  async loadAccount(publicKey: string): Promise<Horizon.AccountResponse> {
+    return this.server.loadAccount(publicKey);
+  }
+
+  /** Builds an unsigned payment transaction and returns it as a base64 XDR envelope. */
+  async buildPaymentTransaction(
+    params: BuildPaymentTransactionParams,
+  ): Promise<string> {
+    const sourceAccount = await this.server.loadAccount(params.sourceAccount);
+    const baseFee = await this.server.fetchBaseFee();
+    const asset =
+      params.assetCode === 'XLM'
+        ? Asset.native()
+        : new Asset(params.assetCode, params.assetIssuer);
+
+    const transaction = new TransactionBuilder(sourceAccount, {
+      fee: String(baseFee),
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(
+        Operation.payment({
+          destination: params.destinationAccount,
+          asset,
+          amount: params.amount,
+        }),
+      )
+      .addMemo(params.memo ? Memo.text(params.memo) : Memo.none())
+      .setTimeout(180)
+      .build();
+
+    return transaction.toXDR();
+  }
+
+  /** Submits an already-signed transaction envelope to Horizon. */
+  async submitTransaction(
+    signedTransactionXdr: string,
+  ): Promise<Horizon.HorizonApi.SubmitTransactionResponse> {
+    const transaction = TransactionBuilder.fromXDR(
+      signedTransactionXdr,
+      this.networkPassphrase,
+    );
+    return this.server.submitTransaction(transaction);
+  }
+}

--- a/backend/src/modules/restaurant/restaurant.entity.ts
+++ b/backend/src/modules/restaurant/restaurant.entity.ts
@@ -14,6 +14,7 @@ import { ContactSubmission } from '../contact/contact-submission.entity';
 import { GalleryImage } from '../gallery/gallery-image.entity';
 import { InstagramPost } from '../instagram/instagram-post.entity';
 import { AuditLog } from '../admin/audit-log.entity';
+import { Order } from '../orders/order.entity';
 
 @Entity('restaurants')
 export class Restaurant {
@@ -64,6 +65,9 @@ export class Restaurant {
 
   @OneToMany(() => AuditLog, (item) => item.restaurant)
   auditLogs: AuditLog[];
+
+  @OneToMany(() => Order, (order) => order.restaurant)
+  orders: Order[];
 
   @CreateDateColumn()
   createdAt: Date;

--- a/docs/adr/0001-payment-custody-model.md
+++ b/docs/adr/0001-payment-custody-model.md
@@ -1,0 +1,92 @@
+# ADR 0001: Payment custody model
+
+- **Status:** Accepted
+- **Date:** 2026-08-21
+- **Related issue:** #312
+
+## Context
+
+The README commits to two payment shapes without ever deciding between them:
+
+- "Restaurant owners receive payments... with automatic conversion to fiat" —
+  implies custodial/anchor involvement on the collection side.
+- Wallet-first UX (Freighter/Albedo/LOBSTR) — implies non-custodial: the
+  diner signs and sends the payment themselves.
+
+Nothing in the codebase resolves this. `.env.example`/README document a
+`STELLAR_MASTER_SECRET`, but no code reads it and no custodial account
+management exists anywhere. The one piece of real evidence is
+`frontend/components/checkout/StellarCheckout.tsx`, which already assumes
+the diner *has their own Stellar wallet address* and enters it directly —
+there is no "we'll hold your funds" onboarding flow anywhere in the UI.
+
+This decision gates the wallet UX design (#315) and the key-management/
+security scope of #316, so it needs to be made once, explicitly, before
+either of those issues can be scoped correctly.
+
+## Decision
+
+**Payment collection is non-custodial.** The diner always signs the payment
+transaction with their own wallet (Freighter/Albedo/LOBSTR); the platform
+never holds diner private keys or diner funds, even transiently.
+
+Concretely, for the service layer landing in this issue:
+
+- `StellarService.buildPaymentTransaction()` returns an **unsigned** XDR
+  envelope. The backend never has access to a diner's signing key.
+- `StellarService.submitTransaction()` only ever submits an
+  **already-signed** envelope handed back to it — it does not sign
+  anything itself.
+- The restaurant's destination account is the restaurant's own Stellar
+  account, supplied when the restaurant is onboarded. Funds settle directly
+  there; the platform is never a middleman holding restaurant balances
+  either.
+
+`STELLAR_MASTER_SECRET`, as documented in the README today, is **not**
+adopted by this decision. No code in this issue reads or needs it — there
+is nothing for the platform to sign on the diner's or restaurant's behalf.
+If a future issue needs a platform-controlled account (e.g. to sponsor
+account-creation reserves for a restaurant's first Stellar account, or to
+collect a platform fee via a path payment), that is a new, narrower
+decision to make explicitly when that need actually arises — it should not
+be assumed to exist just because the env var is documented.
+
+README's "automatic conversion to fiat" is **not** ruled out by this
+decision — it is a restaurant-side concern, not a collection-side one. Once
+a payment settles into a restaurant's own Stellar account, that restaurant
+can independently choose to run received funds through a Stellar anchor
+to off-ramp to fiat. That is a separate integration this ADR does not
+scope or commit to.
+
+## Alternatives considered
+
+- **Custodial**: the platform holds a pooled account and settles
+  internally. Rejected for v1 — it requires key-management infrastructure,
+  custody/security review, and likely regulatory exposure (money
+  transmission) that nothing in the current codebase or roadmap justifies
+  yet, and it contradicts the wallet-first UX already built into
+  `StellarCheckout.tsx`.
+- **Hybrid** (custodial onboarding for new users, non-custodial for
+  wallet-holders): the more flexible long-term answer, but there is no
+  custodial onboarding UI, key-management, or custody-security design
+  anywhere in this codebase today. Building it as a side effect of this
+  foundation issue would be scope creep past what #312 asks for. If
+  diner-side custodial onboarding becomes a real product requirement, it
+  should be its own ADR with its own security review — not folded into
+  this decision by default.
+
+## Consequences
+
+- `StellarService` needs no secret key material at all; it only builds
+  unsigned transactions and submits signed ones. This keeps the service
+  introduced in this issue simple and keeps private keys off the backend
+  entirely.
+- The wallet UX (#315) must support connecting a diner's existing wallet
+  (Freighter/Albedo/LOBSTR) to sign the transaction `StellarService` builds
+  — there is no scenario where the backend signs on the diner's behalf.
+- The key-management/security scope of #316 is correspondingly narrower:
+  there are no diner keys for the platform to protect, because the
+  platform never holds them.
+- Restaurant onboarding needs a destination Stellar account per restaurant
+  (tracked as a follow-up; out of scope for this issue's `Order`/`Payment`
+  schema, which stores `destinationAccount` per payment already).


### PR DESCRIPTION
## Summary

Foundation issue for this payment batch (blocks #313, #314, #315, #316). Before this PR there was no persisted Orders domain at all — `orders.controller.ts` said so directly in its own comment — and zero lines of code talked to Horizon despite both `@stellar/stellar-sdk` and the deprecated `stellar-sdk` being installed.

### Order entity + persistence
- `Order` entity (`backend/src/modules/orders/order.entity.ts`): `restaurantId` FK, line items (jsonb placeholder — the real cart/menu-item-linked creation flow with a validated line-item contract is a later issue in this batch; the current notification-only DTO doesn't collect items yet), `total`, `currency`/asset, `status` enum, timestamps.
- `OrdersController.create`/`updateStatus` now persist through a new `OrdersService` in addition to emitting over `OrdersGateway` — the gateway emission itself is unchanged.
- Tightened `CreateOrderNotificationDto`/`UpdateOrderStatusDto` to validate `status` against the real `OrderStatus` enum instead of an arbitrary string.

### Payment entity
- `Payment` entity (`backend/src/modules/payments/payment.entity.ts`): `orderId` FK, `idempotencyKey` (**unique DB constraint**, not just app-level — the last line of defense against duplicate charges introduced later in this batch), `sourceAccount`/`destinationAccount`, `asset`, `amount`, `status` enum (`pending | submitted | confirmed | failed | expired`), `stellarTxHash` (nullable until submitted), `horizonEnvelopeXdr`, `confirmedAt`.

### StellarService
- Thin wrapper around `@stellar/stellar-sdk`'s `Horizon.Server`: `loadAccount`, `buildPaymentTransaction` (returns an **unsigned** XDR envelope), `submitTransaction` (submits an **already-signed** one). No business logic yet (idempotency, retries, persistence) — that's the next issue.
- Reads `STELLAR_NETWORK`/`STELLAR_HORIZON_URL` from `ConfigService` and **fails fast in `onModuleInit`** if either is missing or the network name isn't recognized, instead of failing only on the first payment attempt.

### Dependency cleanup
- Removed the legacy `stellar-sdk`/`@types/stellar-sdk` packages (confirmed unused via grep before removing). Only `@stellar/stellar-sdk` remains, avoiding two incompatible XDR/keypair implementations coexisting in the tree.

### ADR 0001 — payment custody model
`docs/adr/0001-payment-custody-model.md` decides **non-custodial payment collection**: the diner always signs with their own wallet (Freighter/Albedo/LOBSTR); the platform never holds diner keys or funds. This is grounded in real evidence already in the codebase — `frontend/components/checkout/StellarCheckout.tsx` already assumes the diner has and enters their own wallet address; there's no custodial onboarding UI anywhere. The ADR explicitly addresses the README's undocumented `STELLAR_MASTER_SECRET` (not adopted — nothing in this issue needs it) and clarifies that a restaurant's own later fiat off-ramp via a Stellar anchor is a separate, unblocked concern that this decision doesn't rule out.

## Test plan
- [x] `npm run build` — passes
- [x] `npm run lint` — passes
- [x] `npm run test` — 36 passing (1 intentionally skipped, see below)
  - `OrdersService`: persistence with sensible defaults, status transitions, restaurant-scoped lookups, `NotFoundException` for unknown orders
  - `StellarService`: fail-fast boot validation (missing Horizon URL, missing network, unrecognized network name), network passphrase resolution, `loadAccount` delegation, building both native-XLM and non-native-asset payment transactions, `submitTransaction` round-trip — all against a mocked `Horizon.Server` so the suite stays hermetic
  - A new `stellar.service.integration.spec.ts` satisfies the acceptance criterion ("`StellarService` can load a testnet account and read its balances against the real Horizon testnet") with a **real** network call — it funds a fresh keypair via Friendbot and reads its balances back through `StellarService`. It's gated behind `RUN_STELLAR_INTEGRATION_TESTS=true` so it never runs as part of the hermetic suite CI gates on (this repo's CI only runs `npm run test`, no e2e job, and I didn't want to introduce network flakiness into it). Run it locally with:
    ```
    RUN_STELLAR_INTEGRATION_TESTS=true npm run test -- stellar.service.integration
    ```

Closes #312