### PR TITLE
Payment initiation and idempotent, low-latency transaction submission

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -38,3 +38,6 @@ ADMIN_DEFAULT_PASSWORD=changeme123
 STELLAR_NETWORK=testnet
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 
+# Diner checkout token TTL, in seconds (see docs/adr/0002-diner-checkout-authentication.md)
+CHECKOUT_TOKEN_TTL_SECONDS=900
+

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -27,6 +27,9 @@ import { TokenBlacklistService } from './token-blacklist.service';
   ],
   controllers: [AuthController],
   providers: [AuthService, JwtStrategy, TokenBlacklistService],
-  exports: [AuthService],
+  // JwtModule is exported so other modules that already import AuthModule
+  // (e.g. OrdersModule, for diner checkout tokens — see ADR 0002) can reuse
+  // this same JwtService/secret instead of registering a second JwtModule.
+  exports: [AuthService, JwtModule],
 })
 export class AuthModule {}

--- a/backend/src/modules/orders/checkout-token.service.spec.ts
+++ b/backend/src/modules/orders/checkout-token.service.spec.ts
@@ -1,0 +1,83 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { CheckoutTokenService } from './checkout-token.service';
+
+function makeConfigService(values: Record<string, number> = {}) {
+  return {
+    get: jest.fn((key: string, fallback?: number) => values[key] ?? fallback),
+  };
+}
+
+describe('CheckoutTokenService', () => {
+  const jwtService = new JwtService({ secret: 'test-secret' });
+
+  it('issues a token carrying the diner checkout payload', () => {
+    const service = new CheckoutTokenService(
+      jwtService,
+      makeConfigService() as any,
+    );
+
+    const { token, expiresIn } = service.issue('order-1', 'restaurant-1');
+
+    expect(typeof token).toBe('string');
+    expect(expiresIn).toBe(900);
+
+    const payload = service.verify(token);
+    expect(payload).toEqual(
+      expect.objectContaining({
+        sub: 'diner',
+        type: 'checkout',
+        orderId: 'order-1',
+        restaurantId: 'restaurant-1',
+      }),
+    );
+  });
+
+  it('honors a configured TTL override', () => {
+    const service = new CheckoutTokenService(
+      jwtService,
+      makeConfigService({ CHECKOUT_TOKEN_TTL_SECONDS: 60 }) as any,
+    );
+
+    const { expiresIn } = service.issue('order-1', 'restaurant-1');
+
+    expect(expiresIn).toBe(60);
+  });
+
+  it('rejects a token signed with a different secret', () => {
+    const service = new CheckoutTokenService(
+      jwtService,
+      makeConfigService() as any,
+    );
+    const otherJwtService = new JwtService({ secret: 'a-different-secret' });
+    const foreignToken = otherJwtService.sign({
+      sub: 'diner',
+      type: 'checkout',
+      orderId: 'order-1',
+      restaurantId: 'restaurant-1',
+    });
+
+    expect(() => service.verify(foreignToken)).toThrow(UnauthorizedException);
+  });
+
+  it('rejects a well-formed staff-style JWT (wrong sub/type)', () => {
+    const service = new CheckoutTokenService(
+      jwtService,
+      makeConfigService() as any,
+    );
+    const staffToken = jwtService.sign({ sub: 'staff-user', role: 'admin' });
+
+    expect(() => service.verify(staffToken)).toThrow(UnauthorizedException);
+  });
+
+  it('rejects an expired token', () => {
+    const service = new CheckoutTokenService(
+      jwtService,
+      makeConfigService({ CHECKOUT_TOKEN_TTL_SECONDS: -1 }) as any,
+    );
+
+    const { token } = service.issue('order-1', 'restaurant-1');
+
+    expect(() => service.verify(token)).toThrow(UnauthorizedException);
+  });
+});

--- a/backend/src/modules/orders/checkout-token.service.ts
+++ b/backend/src/modules/orders/checkout-token.service.ts
@@ -1,0 +1,59 @@
+// backend/src/modules/orders/checkout-token.service.ts
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+
+const DEFAULT_TTL_SECONDS = 900; // 15 minutes
+
+export interface CheckoutTokenPayload {
+  sub: 'diner';
+  type: 'checkout';
+  orderId: string;
+  restaurantId: string;
+}
+
+/**
+ * Issues and verifies the short-lived, order-scoped diner checkout token
+ * decided in ADR 0002 (docs/adr/0002-diner-checkout-authentication.md) —
+ * distinct from the staff JWT (modules/auth), and only ever authorizes
+ * acting on the one order it was issued for.
+ */
+@Injectable()
+export class CheckoutTokenService {
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly config: ConfigService,
+  ) {}
+
+  issue(
+    orderId: string,
+    restaurantId: string,
+  ): { token: string; expiresIn: number } {
+    const expiresIn = this.config.get<number>(
+      'CHECKOUT_TOKEN_TTL_SECONDS',
+      DEFAULT_TTL_SECONDS,
+    );
+    const payload: CheckoutTokenPayload = {
+      sub: 'diner',
+      type: 'checkout',
+      orderId,
+      restaurantId,
+    };
+    const token = this.jwtService.sign(payload, { expiresIn });
+    return { token, expiresIn };
+  }
+
+  verify(token: string): CheckoutTokenPayload {
+    let payload: CheckoutTokenPayload;
+    try {
+      payload = this.jwtService.verify<CheckoutTokenPayload>(token);
+    } catch {
+      throw new UnauthorizedException('Invalid or expired checkout token');
+    }
+
+    if (payload.type !== 'checkout' || payload.sub !== 'diner') {
+      throw new UnauthorizedException('Not a valid checkout token');
+    }
+    return payload;
+  }
+}

--- a/backend/src/modules/orders/guards/diner-checkout.guard.spec.ts
+++ b/backend/src/modules/orders/guards/diner-checkout.guard.spec.ts
@@ -1,0 +1,72 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { DinerCheckoutGuard } from './diner-checkout.guard';
+
+function makeContext(headers: Record<string, string> = {}): {
+  context: ExecutionContext;
+  request: any;
+} {
+  const request: any = { headers };
+  const context = {
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+  } as unknown as ExecutionContext;
+  return { context, request };
+}
+
+describe('DinerCheckoutGuard', () => {
+  it('throws UnauthorizedException when no Authorization header is present', () => {
+    const checkoutTokenService = { verify: jest.fn() };
+    const guard = new DinerCheckoutGuard(checkoutTokenService as any);
+    const { context } = makeContext();
+
+    expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+    expect(checkoutTokenService.verify).not.toHaveBeenCalled();
+  });
+
+  it('throws UnauthorizedException when the header is not a Bearer token', () => {
+    const checkoutTokenService = { verify: jest.fn() };
+    const guard = new DinerCheckoutGuard(checkoutTokenService as any);
+    const { context } = makeContext({ authorization: 'Basic abc123' });
+
+    expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+  });
+
+  it('verifies the token and attaches checkoutContext to the request', () => {
+    const checkoutTokenService = {
+      verify: jest.fn().mockReturnValue({
+        sub: 'diner',
+        type: 'checkout',
+        orderId: 'order-1',
+        restaurantId: 'restaurant-1',
+      }),
+    };
+    const guard = new DinerCheckoutGuard(checkoutTokenService as any);
+    const { context, request } = makeContext({
+      authorization: 'Bearer a-valid-token',
+    });
+
+    const result = guard.canActivate(context);
+
+    expect(result).toBe(true);
+    expect(checkoutTokenService.verify).toHaveBeenCalledWith('a-valid-token');
+    expect(request.checkoutContext).toEqual({
+      orderId: 'order-1',
+      restaurantId: 'restaurant-1',
+    });
+  });
+
+  it('propagates the underlying error when verification fails', () => {
+    const checkoutTokenService = {
+      verify: jest.fn().mockImplementation(() => {
+        throw new UnauthorizedException('Invalid or expired checkout token');
+      }),
+    };
+    const guard = new DinerCheckoutGuard(checkoutTokenService as any);
+    const { context } = makeContext({ authorization: 'Bearer expired-token' });
+
+    expect(() => guard.canActivate(context)).toThrow(
+      /Invalid or expired checkout token/,
+    );
+  });
+});

--- a/backend/src/modules/orders/guards/diner-checkout.guard.ts
+++ b/backend/src/modules/orders/guards/diner-checkout.guard.ts
@@ -1,0 +1,51 @@
+// backend/src/modules/orders/guards/diner-checkout.guard.ts
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { CheckoutTokenService } from '../checkout-token.service';
+
+export interface CheckoutContext {
+  orderId: string;
+  restaurantId: string;
+}
+
+export interface CheckoutRequest extends Request {
+  checkoutContext: CheckoutContext;
+}
+
+/**
+ * Verifies the diner checkout token decided in ADR 0002 and attaches
+ * `{ orderId, restaurantId }` to the request. Routes using this guard must
+ * also be marked `@Public()` to bypass the global staff JwtAuthGuard —
+ * this guard is the diner-facing replacement for it, not an addition on
+ * top of it.
+ */
+@Injectable()
+export class DinerCheckoutGuard implements CanActivate {
+  constructor(private readonly checkoutTokenService: CheckoutTokenService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<CheckoutRequest>();
+    const token = this.extractToken(request);
+
+    if (!token) {
+      throw new UnauthorizedException('Missing checkout token');
+    }
+
+    const payload = this.checkoutTokenService.verify(token);
+    request.checkoutContext = {
+      orderId: payload.orderId,
+      restaurantId: payload.restaurantId,
+    };
+    return true;
+  }
+
+  private extractToken(request: Request): string | undefined {
+    const [type, token] = request.headers.authorization?.split(' ') ?? [];
+    return type === 'Bearer' ? token : undefined;
+  }
+}

--- a/backend/src/modules/orders/orders.controller.ts
+++ b/backend/src/modules/orders/orders.controller.ts
@@ -2,6 +2,7 @@
 import {
   Body,
   Controller,
+  Get,
   HttpCode,
   HttpStatus,
   Param,
@@ -15,6 +16,7 @@ import { CreateOrderNotificationDto } from './dto/create-order-notification.dto'
 import { UpdateOrderStatusDto } from './dto/update-order-status.dto';
 import { OrdersGateway } from './orders.gateway';
 import { OrdersService } from './orders.service';
+import { CheckoutTokenService } from './checkout-token.service';
 
 @Controller('orders')
 @UseGuards(JwtAuthGuard)
@@ -22,7 +24,24 @@ export class OrdersController {
   constructor(
     private readonly ordersGateway: OrdersGateway,
     private readonly ordersService: OrdersService,
+    private readonly checkoutTokenService: CheckoutTokenService,
   ) {}
+
+  // Staff-gated (class-level JwtAuthGuard) issuance of the diner-facing
+  // checkout token — see ADR 0002. A staff member/POS system calls this when
+  // seating a table or generating that table's QR code; the token is what
+  // then lets the diner's own device call the payments endpoints for this
+  // one order without a staff session.
+  @Get(':orderId/checkout-token')
+  @HttpCode(HttpStatus.OK)
+  async getCheckoutToken(@Request() req, @Param('orderId') orderId: string) {
+    const order = await this.ordersService.findOne(
+      orderId,
+      req.user.restaurantId,
+    );
+
+    return this.checkoutTokenService.issue(order.id, order.restaurantId);
+  }
 
   @Post()
   @HttpCode(HttpStatus.CREATED)

--- a/backend/src/modules/orders/orders.module.ts
+++ b/backend/src/modules/orders/orders.module.ts
@@ -6,11 +6,23 @@ import { Order } from './order.entity';
 import { OrdersController } from './orders.controller';
 import { OrdersGateway } from './orders.gateway';
 import { OrdersService } from './orders.service';
+import { CheckoutTokenService } from './checkout-token.service';
+import { DinerCheckoutGuard } from './guards/diner-checkout.guard';
 
 @Module({
   imports: [AuthModule, TypeOrmModule.forFeature([Order])],
   controllers: [OrdersController],
-  providers: [OrdersGateway, OrdersService],
-  exports: [OrdersGateway, OrdersService],
+  providers: [
+    OrdersGateway,
+    OrdersService,
+    CheckoutTokenService,
+    DinerCheckoutGuard,
+  ],
+  exports: [
+    OrdersGateway,
+    OrdersService,
+    CheckoutTokenService,
+    DinerCheckoutGuard,
+  ],
 })
 export class OrdersModule {}

--- a/backend/src/modules/orders/orders.service.ts
+++ b/backend/src/modules/orders/orders.service.ts
@@ -34,6 +34,18 @@ export class OrdersService {
     return this.orderRepository.save(order);
   }
 
+  async findOne(orderId: string, restaurantId: string): Promise<Order> {
+    const order = await this.orderRepository.findOne({
+      where: { id: orderId, restaurantId },
+    });
+
+    if (!order) {
+      throw new NotFoundException(`Order ${orderId} not found`);
+    }
+
+    return order;
+  }
+
   async updateStatus(
     orderId: string,
     restaurantId: string,

--- a/backend/src/modules/payments/dto/initiate-payment.dto.ts
+++ b/backend/src/modules/payments/dto/initiate-payment.dto.ts
@@ -1,0 +1,42 @@
+// backend/src/modules/payments/dto/initiate-payment.dto.ts
+import {
+  IsIn,
+  IsNotEmpty,
+  IsNumberString,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Length,
+} from 'class-validator';
+
+export class InitiatePaymentDto {
+  @IsUUID()
+  orderId: string;
+
+  // The diner's own wallet — the transaction's source account. Signing
+  // happens client-side (ADR 0001's non-custodial model); the backend never
+  // holds this account's key.
+  @IsString()
+  @Length(56, 56)
+  sourceAccount: string;
+
+  @IsString()
+  @IsIn(['XLM', 'USDC'])
+  assetCode: string;
+
+  @IsOptional()
+  @IsString()
+  @Length(56, 56)
+  assetIssuer?: string;
+
+  @IsNumberString()
+  amount: string;
+
+  // Supplied by the client (not generated server-side) so a retried HTTP
+  // request after a dropped response reuses the same key instead of minting
+  // a new payment (issue #312/#313's duplicate-charge concern).
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 255)
+  idempotencyKey: string;
+}

--- a/backend/src/modules/payments/dto/submit-signed-payment.dto.ts
+++ b/backend/src/modules/payments/dto/submit-signed-payment.dto.ts
@@ -1,0 +1,8 @@
+// backend/src/modules/payments/dto/submit-signed-payment.dto.ts
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class SubmitSignedPaymentDto {
+  @IsString()
+  @IsNotEmpty()
+  signedTransactionXdr: string;
+}

--- a/backend/src/modules/payments/errors/horizon-error-mapper.ts
+++ b/backend/src/modules/payments/errors/horizon-error-mapper.ts
@@ -1,0 +1,75 @@
+// backend/src/modules/payments/errors/horizon-error-mapper.ts
+import { NotFoundError } from '@stellar/stellar-sdk';
+import {
+  InsufficientBalanceError,
+  MalformedPaymentRequestError,
+  MissingTrustlineError,
+  PaymentError,
+  PaymentSubmissionError,
+  SequenceConflictError,
+} from './payment.errors';
+
+interface TransactionFailedData {
+  extras: {
+    result_codes: {
+      transaction: string;
+      operations?: string[];
+    };
+  };
+}
+
+function isTransactionFailedData(data: unknown): data is TransactionFailedData {
+  const candidate = data as Partial<TransactionFailedData> | undefined;
+  return typeof candidate?.extras?.result_codes?.transaction === 'string';
+}
+
+/**
+ * Maps a Horizon submission failure to a structured, distinguishable
+ * PaymentError instead of letting a generic 500 reach the caller (issue
+ * #313 acceptance criteria). Horizon's own NetworkError subclasses
+ * (BadRequestError et al.) all carry `.response.data` with this shape for
+ * a rejected transaction.
+ */
+export function mapHorizonSubmissionError(error: unknown): PaymentError {
+  const data = (error as { response?: { data?: unknown } } | undefined)
+    ?.response?.data;
+
+  if (isTransactionFailedData(data)) {
+    const txCode = data.extras.result_codes.transaction;
+    const opCodes = data.extras.result_codes.operations ?? [];
+    const rawCodes = { transaction: txCode, operations: opCodes };
+
+    if (txCode === 'tx_bad_seq') {
+      return new SequenceConflictError();
+    }
+    if (
+      txCode === 'tx_insufficient_balance' ||
+      opCodes.includes('op_underfunded') ||
+      opCodes.includes('op_low_reserve')
+    ) {
+      return new InsufficientBalanceError(rawCodes);
+    }
+    if (opCodes.includes('op_no_trust') || opCodes.includes('op_no_issuer')) {
+      return new MissingTrustlineError(rawCodes);
+    }
+    if (
+      txCode === 'tx_bad_auth' ||
+      txCode === 'tx_bad_auth_extra' ||
+      txCode === 'tx_missing_operation' ||
+      opCodes.includes('op_malformed')
+    ) {
+      return new MalformedPaymentRequestError(rawCodes);
+    }
+    return new PaymentSubmissionError(rawCodes);
+  }
+
+  if (error instanceof NotFoundError) {
+    return new PaymentSubmissionError({
+      reason: 'source_or_destination_account_not_found',
+    });
+  }
+
+  return new PaymentSubmissionError(
+    error instanceof Error ? error.message : String(error),
+  );
+}

--- a/backend/src/modules/payments/errors/payment.errors.ts
+++ b/backend/src/modules/payments/errors/payment.errors.ts
@@ -1,0 +1,104 @@
+// backend/src/modules/payments/errors/payment.errors.ts
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+/**
+ * Every structured payment error carries a stable `code` in its response
+ * body, distinct from the HTTP status, so #315's frontend can branch on
+ * the specific failure rather than parsing a message string (issue #313:
+ * "must surface a structured error, not a generic 500").
+ */
+export type PaymentErrorCode =
+  | 'INSUFFICIENT_BALANCE'
+  | 'MISSING_TRUSTLINE'
+  | 'SEQUENCE_CONFLICT'
+  | 'MALFORMED_REQUEST'
+  | 'IDEMPOTENCY_CONFLICT'
+  | 'RESTAURANT_WALLET_NOT_CONFIGURED'
+  | 'SUBMISSION_FAILED';
+
+export abstract class PaymentError extends HttpException {
+  protected constructor(
+    readonly code: PaymentErrorCode,
+    message: string,
+    status: HttpStatus,
+    details?: unknown,
+  ) {
+    super({ code, message, details }, status);
+  }
+}
+
+export class InsufficientBalanceError extends PaymentError {
+  constructor(details?: unknown) {
+    super(
+      'INSUFFICIENT_BALANCE',
+      'Source account has insufficient balance for this payment',
+      HttpStatus.UNPROCESSABLE_ENTITY,
+      details,
+    );
+  }
+}
+
+export class MissingTrustlineError extends PaymentError {
+  constructor(details?: unknown) {
+    super(
+      'MISSING_TRUSTLINE',
+      'An account is missing a trustline for this asset',
+      HttpStatus.UNPROCESSABLE_ENTITY,
+      details,
+    );
+  }
+}
+
+/**
+ * The signed transaction's sequence number is stale — this can only
+ * happen for a transaction that's already signed, so we cannot silently
+ * "retry" (a new sequence requires a new signature). The caller must
+ * re-initiate the payment.
+ */
+export class SequenceConflictError extends PaymentError {
+  constructor() {
+    super(
+      'SEQUENCE_CONFLICT',
+      'This payment’s transaction sequence is stale — please re-initiate the payment',
+      HttpStatus.CONFLICT,
+    );
+  }
+}
+
+export class MalformedPaymentRequestError extends PaymentError {
+  constructor(details?: unknown) {
+    super(
+      'MALFORMED_REQUEST',
+      'The network rejected this request as malformed',
+      HttpStatus.BAD_REQUEST,
+      details,
+    );
+  }
+}
+
+export class IdempotencyConflictError extends PaymentError {
+  constructor(message: string) {
+    super('IDEMPOTENCY_CONFLICT', message, HttpStatus.CONFLICT);
+  }
+}
+
+export class RestaurantWalletNotConfiguredError extends PaymentError {
+  constructor() {
+    super(
+      'RESTAURANT_WALLET_NOT_CONFIGURED',
+      'This restaurant has not configured a Stellar wallet yet',
+      HttpStatus.UNPROCESSABLE_ENTITY,
+    );
+  }
+}
+
+export class PaymentSubmissionError extends PaymentError {
+  constructor(details?: unknown) {
+    super(
+      'SUBMISSION_FAILED',
+      'The transaction was rejected by the network',
+      HttpStatus.UNPROCESSABLE_ENTITY,
+      details,
+    );
+  }
+}

--- a/backend/src/modules/payments/payment.entity.ts
+++ b/backend/src/modules/payments/payment.entity.ts
@@ -64,6 +64,12 @@ export class Payment {
   @Column({ type: 'timestamp', nullable: true })
   confirmedAt: Date | null;
 
+  // Populated when status transitions to FAILED — a typed PaymentErrorCode
+  // (see errors/payment.errors.ts), not a raw Horizon/stack-trace dump, so
+  // it's safe to surface back to the diner-facing client.
+  @Column({ type: 'varchar', length: 64, nullable: true })
+  failureReason: string | null;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/backend/src/modules/payments/payments.controller.ts
+++ b/backend/src/modules/payments/payments.controller.ts
@@ -1,0 +1,69 @@
+// backend/src/modules/payments/payments.controller.ts
+import {
+  Body,
+  Controller,
+  Param,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { Public } from '../../common/decorators/public.decorator';
+import {
+  DinerCheckoutGuard,
+  CheckoutRequest,
+} from '../orders/guards/diner-checkout.guard';
+import { InitiatePaymentDto } from './dto/initiate-payment.dto';
+import { SubmitSignedPaymentDto } from './dto/submit-signed-payment.dto';
+import { PaymentsService } from './payments.service';
+import { MalformedPaymentRequestError } from './errors/payment.errors';
+
+// Diner-facing, not staff-facing (see ADR 0002) — @Public() bypasses the
+// global staff JwtAuthGuard, and DinerCheckoutGuard is the real gate here.
+@Controller('payments/stellar')
+@Public()
+@UseGuards(DinerCheckoutGuard)
+export class PaymentsController {
+  constructor(private readonly paymentsService: PaymentsService) {}
+
+  // Throttled tighter than the app default — a diner initiates a payment
+  // once per checkout, not in a tight loop; this bounds abuse of an
+  // otherwise-expensive (Horizon round trip) endpoint.
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
+  @Post('initiate')
+  async initiate(
+    @Request() req: CheckoutRequest,
+    @Body() dto: InitiatePaymentDto,
+  ) {
+    this.assertMatchesCheckoutOrder(req, dto.orderId);
+    return this.paymentsService.initiate(dto);
+  }
+
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
+  @Post(':paymentId/submit-signed')
+  async submitSigned(
+    @Request() req: CheckoutRequest,
+    @Param('paymentId') paymentId: string,
+    @Body() dto: SubmitSignedPaymentDto,
+  ) {
+    return this.paymentsService.submitSigned(
+      paymentId,
+      req.checkoutContext.orderId,
+      dto,
+    );
+  }
+
+  // A valid checkout token only ever authorizes the order it was issued
+  // for (ADR 0002) — this stops a token for order A being replayed against
+  // a payment request naming order B.
+  private assertMatchesCheckoutOrder(
+    req: CheckoutRequest,
+    orderId: string,
+  ): void {
+    if (req.checkoutContext.orderId !== orderId) {
+      throw new MalformedPaymentRequestError({
+        reason: 'orderId does not match checkout token',
+      });
+    }
+  }
+}

--- a/backend/src/modules/payments/payments.module.ts
+++ b/backend/src/modules/payments/payments.module.ts
@@ -2,14 +2,21 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Payment } from './payment.entity';
+import { Order } from '../orders/order.entity';
+import { Restaurant } from '../restaurant/restaurant.entity';
 import { StellarService } from './stellar.service';
+import { SequenceAllocator } from './sequence-allocator.service';
+import { PaymentsService } from './payments.service';
+import { PaymentsController } from './payments.controller';
+import { OrdersModule } from '../orders/orders.module';
 
-// No HTTP endpoints yet — this issue only establishes the persisted
-// schema and the Stellar service scaffolding. Payment initiation
-// endpoints and business logic land in the next issue of this batch.
 @Module({
-  imports: [TypeOrmModule.forFeature([Payment])],
-  providers: [StellarService],
+  imports: [
+    TypeOrmModule.forFeature([Payment, Order, Restaurant]),
+    OrdersModule,
+  ],
+  controllers: [PaymentsController],
+  providers: [StellarService, SequenceAllocator, PaymentsService],
   exports: [StellarService],
 })
 export class PaymentsModule {}

--- a/backend/src/modules/payments/payments.service.spec.ts
+++ b/backend/src/modules/payments/payments.service.spec.ts
@@ -1,0 +1,303 @@
+import { QueryFailedError } from 'typeorm';
+import { PaymentsService } from './payments.service';
+import { PaymentStatus } from './payment.entity';
+import {
+  IdempotencyConflictError,
+  InsufficientBalanceError,
+  MalformedPaymentRequestError,
+  RestaurantWalletNotConfiguredError,
+  SequenceConflictError,
+} from './errors/payment.errors';
+
+type MockRepository = {
+  create: jest.Mock;
+  save: jest.Mock;
+  findOne: jest.Mock;
+};
+
+function makeRepository(): MockRepository {
+  return {
+    create: jest.fn((data) => ({ ...data })),
+    save: jest.fn(async (entity) => entity),
+    findOne: jest.fn(),
+  };
+}
+
+function makeUniqueViolation(): QueryFailedError {
+  return new QueryFailedError('INSERT INTO payments...', [], {
+    name: 'error',
+    message: 'duplicate key value violates unique constraint',
+    code: '23505',
+  } as any);
+}
+
+describe('PaymentsService', () => {
+  let paymentRepository: MockRepository;
+  let orderRepository: MockRepository;
+  let restaurantRepository: MockRepository;
+  let stellarService: { buildPaymentTransaction: jest.Mock; submitTransaction: jest.Mock };
+  let sequenceAllocator: { allocate: jest.Mock; invalidate: jest.Mock };
+  let service: PaymentsService;
+
+  const order = { id: 'order-1', restaurantId: 'restaurant-1', orderNumber: 'ORD-1' };
+  const restaurant = { id: 'restaurant-1', stellarWalletAddress: 'GDEST...' };
+
+  const baseDto = {
+    orderId: 'order-1',
+    sourceAccount: 'GSOURCE...',
+    assetCode: 'XLM',
+    amount: '10.0000000',
+    idempotencyKey: 'idem-key-1',
+  };
+
+  beforeEach(() => {
+    paymentRepository = makeRepository();
+    orderRepository = makeRepository();
+    restaurantRepository = makeRepository();
+    stellarService = {
+      buildPaymentTransaction: jest.fn().mockResolvedValue('unsigned-xdr'),
+      submitTransaction: jest.fn(),
+    };
+    sequenceAllocator = {
+      allocate: jest.fn().mockResolvedValue('101'),
+      invalidate: jest.fn(),
+    };
+
+    service = new PaymentsService(
+      paymentRepository as any,
+      orderRepository as any,
+      restaurantRepository as any,
+      stellarService as any,
+      sequenceAllocator as any,
+    );
+
+    paymentRepository.findOne.mockResolvedValue(null);
+    orderRepository.findOne.mockResolvedValue(order);
+    restaurantRepository.findOne.mockResolvedValue(restaurant);
+  });
+
+  describe('initiate', () => {
+    it('allocates a sequence, builds the transaction and persists a pending payment', async () => {
+      const result = await service.initiate(baseDto);
+
+      expect(sequenceAllocator.allocate).toHaveBeenCalledWith('GSOURCE...');
+      expect(stellarService.buildPaymentTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceAccount: 'GSOURCE...',
+          destinationAccount: 'GDEST...',
+          assetCode: 'XLM',
+          amount: '10.0000000',
+          sequenceOverride: '101',
+        }),
+      );
+      expect(paymentRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          idempotencyKey: 'idem-key-1',
+          status: PaymentStatus.PENDING,
+        }),
+      );
+      expect(result.unsignedTransactionXdr).toBe('unsigned-xdr');
+      expect(result.status).toBe(PaymentStatus.PENDING);
+    });
+
+    it('rejects a non-XLM asset with no issuer as malformed', async () => {
+      await expect(
+        service.initiate({ ...baseDto, assetCode: 'USDC' }),
+      ).rejects.toThrow(MalformedPaymentRequestError);
+
+      expect(sequenceAllocator.allocate).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown orderId as malformed', async () => {
+      orderRepository.findOne.mockResolvedValueOnce(null);
+
+      await expect(service.initiate(baseDto)).rejects.toThrow(
+        MalformedPaymentRequestError,
+      );
+    });
+
+    it('rejects when the restaurant has no configured wallet', async () => {
+      restaurantRepository.findOne.mockResolvedValueOnce({
+        id: 'restaurant-1',
+        stellarWalletAddress: null,
+      });
+
+      await expect(service.initiate(baseDto)).rejects.toThrow(
+        RestaurantWalletNotConfiguredError,
+      );
+    });
+
+    it('replays the existing result for a repeated idempotency key on the same order', async () => {
+      paymentRepository.findOne.mockResolvedValueOnce({
+        id: 'existing-payment',
+        orderId: 'order-1',
+        status: PaymentStatus.PENDING,
+        horizonEnvelopeXdr: 'already-built-xdr',
+      });
+
+      const result = await service.initiate(baseDto);
+
+      expect(result).toEqual({
+        paymentId: 'existing-payment',
+        status: PaymentStatus.PENDING,
+        unsignedTransactionXdr: 'already-built-xdr',
+      });
+      expect(sequenceAllocator.allocate).not.toHaveBeenCalled();
+      expect(stellarService.buildPaymentTransaction).not.toHaveBeenCalled();
+    });
+
+    it('rejects reusing an idempotency key across different orders', async () => {
+      paymentRepository.findOne.mockResolvedValueOnce({
+        id: 'existing-payment',
+        orderId: 'a-different-order',
+        status: PaymentStatus.PENDING,
+        horizonEnvelopeXdr: 'already-built-xdr',
+      });
+
+      await expect(service.initiate(baseDto)).rejects.toThrow(
+        IdempotencyConflictError,
+      );
+    });
+
+    it('resolves to the racing writer’s row when two concurrent inserts collide on idempotencyKey', async () => {
+      // First findOne (idempotency check) sees nothing; the save() then
+      // hits the DB unique constraint because another request won the
+      // race in between — this is the actual concurrency guarantee
+      // (issue #313), not just the earlier findOne check.
+      paymentRepository.save.mockRejectedValueOnce(makeUniqueViolation());
+      paymentRepository.findOne.mockResolvedValueOnce(null); // idempotency check
+      paymentRepository.findOne.mockResolvedValueOnce({
+        id: 'raced-in-payment',
+        orderId: 'order-1',
+        status: PaymentStatus.PENDING,
+        horizonEnvelopeXdr: 'unsigned-xdr',
+      }); // re-fetch after unique violation
+
+      const result = await service.initiate(baseDto);
+
+      expect(result.paymentId).toBe('raced-in-payment');
+    });
+  });
+
+  describe('submitSigned', () => {
+    it('submits to Horizon and marks the payment confirmed', async () => {
+      paymentRepository.findOne.mockResolvedValueOnce({
+        id: 'payment-1',
+        orderId: 'order-1',
+        sourceAccount: 'GSOURCE...',
+        status: PaymentStatus.PENDING,
+      });
+      stellarService.submitTransaction.mockResolvedValueOnce({
+        hash: 'tx-hash-1',
+        successful: true,
+      });
+
+      const result = await service.submitSigned('payment-1', 'order-1', {
+        signedTransactionXdr: 'signed-xdr',
+      });
+
+      expect(result).toEqual({
+        paymentId: 'payment-1',
+        status: PaymentStatus.CONFIRMED,
+        stellarTxHash: 'tx-hash-1',
+      });
+      expect(paymentRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: PaymentStatus.CONFIRMED,
+          stellarTxHash: 'tx-hash-1',
+        }),
+      );
+    });
+
+    it('is a no-op replay for an already-confirmed payment', async () => {
+      paymentRepository.findOne.mockResolvedValueOnce({
+        id: 'payment-1',
+        orderId: 'order-1',
+        sourceAccount: 'GSOURCE...',
+        status: PaymentStatus.CONFIRMED,
+        stellarTxHash: 'tx-hash-1',
+      });
+
+      const result = await service.submitSigned('payment-1', 'order-1', {
+        signedTransactionXdr: 'signed-xdr',
+      });
+
+      expect(result.status).toBe(PaymentStatus.CONFIRMED);
+      expect(stellarService.submitTransaction).not.toHaveBeenCalled();
+      expect(paymentRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unknown paymentId as malformed', async () => {
+      paymentRepository.findOne.mockResolvedValueOnce(null);
+
+      await expect(
+        service.submitSigned('missing-payment', 'order-1', {
+          signedTransactionXdr: 'signed-xdr',
+        }),
+      ).rejects.toThrow(MalformedPaymentRequestError);
+    });
+
+    it('maps a tx_bad_seq rejection to SequenceConflictError and invalidates the cached sequence', async () => {
+      paymentRepository.findOne.mockResolvedValueOnce({
+        id: 'payment-1',
+        orderId: 'order-1',
+        sourceAccount: 'GSOURCE...',
+        status: PaymentStatus.PENDING,
+      });
+      stellarService.submitTransaction.mockRejectedValueOnce({
+        response: {
+          data: { extras: { result_codes: { transaction: 'tx_bad_seq' } } },
+        },
+      });
+
+      await expect(
+        service.submitSigned('payment-1', 'order-1', {
+          signedTransactionXdr: 'signed-xdr',
+        }),
+      ).rejects.toThrow(SequenceConflictError);
+
+      expect(sequenceAllocator.invalidate).toHaveBeenCalledWith('GSOURCE...');
+      expect(paymentRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: PaymentStatus.FAILED,
+          failureReason: 'SEQUENCE_CONFLICT',
+        }),
+      );
+    });
+
+    it('maps an underfunded rejection to InsufficientBalanceError without invalidating the sequence', async () => {
+      paymentRepository.findOne.mockResolvedValueOnce({
+        id: 'payment-1',
+        orderId: 'order-1',
+        sourceAccount: 'GSOURCE...',
+        status: PaymentStatus.PENDING,
+      });
+      stellarService.submitTransaction.mockRejectedValueOnce({
+        response: {
+          data: {
+            extras: {
+              result_codes: {
+                transaction: 'tx_failed',
+                operations: ['op_underfunded'],
+              },
+            },
+          },
+        },
+      });
+
+      await expect(
+        service.submitSigned('payment-1', 'order-1', {
+          signedTransactionXdr: 'signed-xdr',
+        }),
+      ).rejects.toThrow(InsufficientBalanceError);
+
+      expect(sequenceAllocator.invalidate).not.toHaveBeenCalled();
+      expect(paymentRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: PaymentStatus.FAILED,
+          failureReason: 'INSUFFICIENT_BALANCE',
+        }),
+      );
+    });
+  });
+});

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -1,0 +1,219 @@
+// backend/src/modules/payments/payments.service.ts
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
+import { Order } from '../orders/order.entity';
+import { Restaurant } from '../restaurant/restaurant.entity';
+import { Payment, PaymentStatus } from './payment.entity';
+import { StellarService } from './stellar.service';
+import { SequenceAllocator } from './sequence-allocator.service';
+import { InitiatePaymentDto } from './dto/initiate-payment.dto';
+import { SubmitSignedPaymentDto } from './dto/submit-signed-payment.dto';
+import { mapHorizonSubmissionError } from './errors/horizon-error-mapper';
+import {
+  IdempotencyConflictError,
+  MalformedPaymentRequestError,
+  RestaurantWalletNotConfiguredError,
+  SequenceConflictError,
+} from './errors/payment.errors';
+
+// Postgres unique_violation — see https://www.postgresql.org/docs/current/errcodes-appendix.html
+const POSTGRES_UNIQUE_VIOLATION = '23505';
+
+export interface InitiatePaymentResult {
+  paymentId: string;
+  status: PaymentStatus;
+  unsignedTransactionXdr: string;
+}
+
+export interface SubmitSignedPaymentResult {
+  paymentId: string;
+  status: PaymentStatus;
+  stellarTxHash: string | null;
+}
+
+@Injectable()
+export class PaymentsService {
+  private readonly logger = new Logger(PaymentsService.name);
+
+  constructor(
+    @InjectRepository(Payment)
+    private readonly paymentRepository: Repository<Payment>,
+    @InjectRepository(Order)
+    private readonly orderRepository: Repository<Order>,
+    @InjectRepository(Restaurant)
+    private readonly restaurantRepository: Repository<Restaurant>,
+    private readonly stellarService: StellarService,
+    private readonly sequenceAllocator: SequenceAllocator,
+  ) {}
+
+  async initiate(dto: InitiatePaymentDto): Promise<InitiatePaymentResult> {
+    const existing = await this.paymentRepository.findOne({
+      where: { idempotencyKey: dto.idempotencyKey },
+    });
+    if (existing) {
+      return this.replayInitiate(existing, dto);
+    }
+
+    if (dto.assetCode !== 'XLM' && !dto.assetIssuer) {
+      throw new MalformedPaymentRequestError({
+        reason: 'assetIssuer is required for non-XLM assets',
+      });
+    }
+
+    const order = await this.orderRepository.findOne({
+      where: { id: dto.orderId },
+    });
+    if (!order) {
+      throw new MalformedPaymentRequestError({ reason: 'unknown orderId' });
+    }
+
+    const restaurant = await this.restaurantRepository.findOne({
+      where: { id: order.restaurantId },
+    });
+    if (!restaurant?.stellarWalletAddress) {
+      throw new RestaurantWalletNotConfiguredError();
+    }
+
+    const sequence = await this.sequenceAllocator.allocate(dto.sourceAccount);
+    const unsignedTransactionXdr =
+      await this.stellarService.buildPaymentTransaction({
+        sourceAccount: dto.sourceAccount,
+        destinationAccount: restaurant.stellarWalletAddress,
+        assetCode: dto.assetCode,
+        assetIssuer: dto.assetIssuer,
+        amount: dto.amount,
+        memo: order.orderNumber,
+        sequenceOverride: sequence,
+      });
+
+    const payment = await this.createPayment(
+      dto,
+      restaurant,
+      unsignedTransactionXdr,
+    );
+
+    return {
+      paymentId: payment.id,
+      status: payment.status,
+      unsignedTransactionXdr,
+    };
+  }
+
+  // Handles the race where two concurrent requests for the same
+  // idempotencyKey both miss the initial findOne and both try to build/save
+  // — the DB's unique constraint on idempotencyKey (see payment.entity.ts)
+  // is the actual source of truth; this just turns that constraint
+  // violation into the same replay response a sequential caller would get.
+  private async createPayment(
+    dto: InitiatePaymentDto,
+    restaurant: Restaurant,
+    unsignedTransactionXdr: string,
+  ): Promise<Payment> {
+    const payment = this.paymentRepository.create({
+      orderId: dto.orderId,
+      idempotencyKey: dto.idempotencyKey,
+      sourceAccount: dto.sourceAccount,
+      destinationAccount: restaurant.stellarWalletAddress as string,
+      asset: dto.assetCode,
+      amount: Number(dto.amount),
+      status: PaymentStatus.PENDING,
+      horizonEnvelopeXdr: unsignedTransactionXdr,
+    });
+
+    try {
+      return await this.paymentRepository.save(payment);
+    } catch (error) {
+      if (this.isUniqueViolation(error)) {
+        const raced = await this.paymentRepository.findOne({
+          where: { idempotencyKey: dto.idempotencyKey },
+        });
+        if (raced) {
+          return raced;
+        }
+      }
+      throw error;
+    }
+  }
+
+  private replayInitiate(
+    existing: Payment,
+    dto: InitiatePaymentDto,
+  ): InitiatePaymentResult {
+    if (existing.orderId !== dto.orderId) {
+      throw new IdempotencyConflictError(
+        'This idempotency key was already used for a different order',
+      );
+    }
+
+    return {
+      paymentId: existing.id,
+      status: existing.status,
+      unsignedTransactionXdr: existing.horizonEnvelopeXdr ?? '',
+    };
+  }
+
+  async submitSigned(
+    paymentId: string,
+    orderId: string,
+    dto: SubmitSignedPaymentDto,
+  ): Promise<SubmitSignedPaymentResult> {
+    const payment = await this.paymentRepository.findOne({
+      where: { id: paymentId, orderId },
+    });
+    if (!payment) {
+      throw new MalformedPaymentRequestError({ reason: 'unknown paymentId' });
+    }
+
+    // Already-terminal payments are a no-op replay, not a resubmission —
+    // the client may retry after a dropped HTTP response even though the
+    // first submission already reached Horizon.
+    if (
+      payment.status === PaymentStatus.SUBMITTED ||
+      payment.status === PaymentStatus.CONFIRMED
+    ) {
+      return {
+        paymentId: payment.id,
+        status: payment.status,
+        stellarTxHash: payment.stellarTxHash,
+      };
+    }
+
+    try {
+      const response = await this.stellarService.submitTransaction(
+        dto.signedTransactionXdr,
+      );
+
+      payment.status = PaymentStatus.CONFIRMED;
+      payment.stellarTxHash = response.hash;
+      payment.horizonEnvelopeXdr = dto.signedTransactionXdr;
+      payment.confirmedAt = new Date();
+      await this.paymentRepository.save(payment);
+
+      return {
+        paymentId: payment.id,
+        status: payment.status,
+        stellarTxHash: payment.stellarTxHash,
+      };
+    } catch (error) {
+      const mapped = mapHorizonSubmissionError(error);
+
+      if (mapped instanceof SequenceConflictError) {
+        this.sequenceAllocator.invalidate(payment.sourceAccount);
+      }
+
+      payment.status = PaymentStatus.FAILED;
+      payment.failureReason = mapped.code;
+      await this.paymentRepository.save(payment);
+
+      throw mapped;
+    }
+  }
+
+  private isUniqueViolation(error: unknown): boolean {
+    return (
+      error instanceof QueryFailedError &&
+      (error as unknown as { code?: string }).code === POSTGRES_UNIQUE_VIOLATION
+    );
+  }
+}

--- a/backend/src/modules/payments/sequence-allocator.service.spec.ts
+++ b/backend/src/modules/payments/sequence-allocator.service.spec.ts
@@ -1,0 +1,73 @@
+import { SequenceAllocator } from './sequence-allocator.service';
+
+function makeStellarService(initialSequence: string) {
+  return {
+    loadAccount: jest.fn().mockResolvedValue({ sequence: initialSequence }),
+  };
+}
+
+describe('SequenceAllocator', () => {
+  describe('allocate', () => {
+    it('returns account.sequence + 1 for the first allocation', async () => {
+      const stellarService = makeStellarService('100');
+      const allocator = new SequenceAllocator(stellarService as any);
+
+      const sequence = await allocator.allocate('GACCOUNT');
+
+      expect(sequence).toBe('101');
+      expect(stellarService.loadAccount).toHaveBeenCalledTimes(1);
+    });
+
+    it('hands out consecutive sequences without refetching', async () => {
+      const stellarService = makeStellarService('100');
+      const allocator = new SequenceAllocator(stellarService as any);
+
+      const first = await allocator.allocate('GACCOUNT');
+      const second = await allocator.allocate('GACCOUNT');
+      const third = await allocator.allocate('GACCOUNT');
+
+      expect([first, second, third]).toEqual(['101', '102', '103']);
+      expect(stellarService.loadAccount).toHaveBeenCalledTimes(1);
+    });
+
+    it('serializes concurrent allocations for the same account (no duplicate sequences)', async () => {
+      const stellarService = makeStellarService('100');
+      const allocator = new SequenceAllocator(stellarService as any);
+
+      const results = await Promise.all(
+        Array.from({ length: 20 }, () => allocator.allocate('GACCOUNT')),
+      );
+
+      expect(new Set(results).size).toBe(20);
+      expect(stellarService.loadAccount).toHaveBeenCalledTimes(1);
+    });
+
+    it('tracks separate accounts independently', async () => {
+      const stellarService = makeStellarService('100');
+      const allocator = new SequenceAllocator(stellarService as any);
+
+      const a = await allocator.allocate('GACCOUNT_A');
+      const b = await allocator.allocate('GACCOUNT_B');
+
+      expect(a).toBe('101');
+      expect(b).toBe('101');
+      expect(stellarService.loadAccount).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('invalidate', () => {
+    it('forces the next allocation to refetch from Horizon', async () => {
+      const stellarService = makeStellarService('100');
+      const allocator = new SequenceAllocator(stellarService as any);
+
+      await allocator.allocate('GACCOUNT');
+      allocator.invalidate('GACCOUNT');
+
+      stellarService.loadAccount.mockResolvedValueOnce({ sequence: '200' });
+      const sequence = await allocator.allocate('GACCOUNT');
+
+      expect(sequence).toBe('201');
+      expect(stellarService.loadAccount).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/backend/src/modules/payments/sequence-allocator.service.ts
+++ b/backend/src/modules/payments/sequence-allocator.service.ts
@@ -1,0 +1,66 @@
+// backend/src/modules/payments/sequence-allocator.service.ts
+import { Injectable, Logger } from '@nestjs/common';
+import { StellarService } from './stellar.service';
+
+/**
+ * Hands out sequence numbers for building Stellar transactions, one at a
+ * time per source account (issue #313: "Serialize sequence-number
+ * allocation per source account and retry-with-refetch on tx_bad_seq").
+ *
+ * Horizon's account sequence only advances once a transaction actually
+ * lands on-ledger — it does NOT advance just because we built (or even
+ * signed) a transaction. Two builds for the same account issued back to
+ * back would both read the same not-yet-incremented value from
+ * loadAccount() and collide. This keeps an optimistic, in-process
+ * next-sequence cache per account instead, advancing it the moment a
+ * sequence is handed out rather than waiting for confirmation, and
+ * serializes access per account so concurrent callers never read the same
+ * cached value.
+ *
+ * If Horizon still rejects a submission with tx_bad_seq (our cached value
+ * drifted from reality — e.g. a transaction we allocated for was abandoned
+ * instead of submitted), invalidate() forces the next allocation for that
+ * account to refetch fresh from Horizon rather than keep handing out
+ * increasingly wrong values.
+ */
+@Injectable()
+export class SequenceAllocator {
+  private readonly logger = new Logger(SequenceAllocator.name);
+  private readonly nextSequence = new Map<string, bigint>();
+  private readonly queues = new Map<string, Promise<unknown>>();
+
+  constructor(private readonly stellarService: StellarService) {}
+
+  async allocate(sourceAccount: string): Promise<string> {
+    return this.runExclusive(sourceAccount, async () => {
+      let next = this.nextSequence.get(sourceAccount);
+      if (next === undefined) {
+        const account = await this.stellarService.loadAccount(sourceAccount);
+        next = BigInt(account.sequence) + 1n;
+      } else {
+        next += 1n;
+      }
+      this.nextSequence.set(sourceAccount, next);
+      return next.toString();
+    });
+  }
+
+  invalidate(sourceAccount: string): void {
+    this.logger.warn(
+      `Invalidating cached sequence for ${sourceAccount} after a tx_bad_seq rejection`,
+    );
+    this.nextSequence.delete(sourceAccount);
+  }
+
+  /** Runs `fn` after every previously-queued call for `key` has settled, one at a time. */
+  private async runExclusive<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const previousTail = this.queues.get(key) ?? Promise.resolve();
+    const settledPrevious = previousTail.catch(() => undefined);
+    const run = settledPrevious.then(fn);
+    this.queues.set(
+      key,
+      run.catch(() => undefined),
+    );
+    return run;
+  }
+}

--- a/backend/src/modules/payments/stellar.service.ts
+++ b/backend/src/modules/payments/stellar.service.ts
@@ -2,6 +2,7 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import {
+  Account,
   Asset,
   Horizon,
   Memo,
@@ -20,6 +21,15 @@ export interface BuildPaymentTransactionParams {
   /** Decimal string, e.g. "12.5000000" — never a float, to avoid precision loss. */
   amount: string;
   memo?: string;
+  /**
+   * The exact sequence number this transaction should carry (i.e. what
+   * SequenceAllocator.allocate() returns), NOT the account's current
+   * on-ledger sequence. TransactionBuilder always builds a transaction
+   * whose seqNum is `source.sequenceNumber() + 1`, so callers supplying
+   * this must not also expect the usual +1 — buildPaymentTransaction
+   * compensates by constructing the Account one below this value.
+   */
+  sequenceOverride?: string;
 }
 
 /**
@@ -88,7 +98,12 @@ export class StellarService implements OnModuleInit {
   async buildPaymentTransaction(
     params: BuildPaymentTransactionParams,
   ): Promise<string> {
-    const sourceAccount = await this.server.loadAccount(params.sourceAccount);
+    const sourceAccount = params.sequenceOverride
+      ? new Account(
+          params.sourceAccount,
+          (BigInt(params.sequenceOverride) - 1n).toString(),
+        )
+      : await this.server.loadAccount(params.sourceAccount);
     const baseFee = await this.server.fetchBaseFee();
     const asset =
       params.assetCode === 'XLM'

--- a/backend/src/modules/restaurant/restaurant.entity.ts
+++ b/backend/src/modules/restaurant/restaurant.entity.ts
@@ -42,6 +42,13 @@ export class Restaurant {
   @Column({ type: 'boolean', default: true })
   isActive: boolean;
 
+  // Destination account for Stellar payments (see modules/payments, #313).
+  // Nullable because not every restaurant has onboarded a wallet yet —
+  // PaymentsService rejects initiation with RestaurantWalletNotConfiguredError
+  // when this is unset rather than treating it as a required column.
+  @Column({ type: 'varchar', length: 56, nullable: true })
+  stellarWalletAddress: string | null;
+
   @Column({ type: 'jsonb', nullable: true })
   settings: Record<string, any>; // Store restaurant-specific settings
 

--- a/docs/adr/0002-diner-checkout-authentication.md
+++ b/docs/adr/0002-diner-checkout-authentication.md
@@ -1,0 +1,72 @@
+# ADR 0002: Diner checkout authentication
+
+- **Status:** Accepted
+- **Date:** 2026-08-21
+- **Related issue:** #313
+
+## Context
+
+Every existing authenticated route in this backend assumes a **staff member**:
+`JwtAuthGuard` verifies a token against the `AdminUser` table and attaches
+`restaurantId`/`role` to the request (`modules/auth/jwt.strategy.ts`). A diner
+scanning a QR code at their table and paying for their own order is not a
+staff member and has no `AdminUser` row — there is no diner identity model
+in this codebase at all today.
+
+`PaymentsController`'s `initiate`/`submit-signed` endpoints are diner-facing.
+Left unguarded (or guarded by the existing staff `JwtAuthGuard`), either the
+endpoint is wide open to anyone who knows an `orderId`, or diners simply
+cannot use it.
+
+## Decision
+
+A diner's payment request is authorized by a **short-lived, order-scoped
+checkout token** — a JWT distinct from the staff token, carrying
+`{ sub: 'diner', type: 'checkout', orderId, restaurantId }` and expiring in
+`CHECKOUT_TOKEN_TTL_SECONDS` (default 15 minutes — long enough to complete a
+checkout, short enough that a leaked/logged URL stops working quickly).
+
+- **Issuance:** `GET /orders/:orderId/checkout-token`, gated by the existing
+  staff `JwtAuthGuard` (a staff member/POS system requests it when seating a
+  table or printing/generating that table's QR code). The QR code encodes a
+  URL containing this token; scanning it is what gives a diner's phone the
+  authority to pay for that specific order.
+- **Verification:** `DinerCheckoutGuard` (`modules/orders/guards/`) verifies
+  the token and attaches `{ orderId, restaurantId }` to the request.
+  `PaymentsController` marks its diner-facing routes `@Public()` (bypassing
+  the global staff `JwtAuthGuard`) and applies `DinerCheckoutGuard` instead.
+- **Scoping:** every payment-mutating call re-checks that the token's
+  `orderId` matches the `orderId` being acted on — a valid token for order A
+  can never be used to touch order B, even by request forgery.
+
+This is deliberately **stateless** (no session table, no diner accounts) —
+consistent with ADR 0001's non-custodial decision: the platform doesn't hold
+diner identity any more than it holds diner funds. It is not a general-purpose
+diner auth system; it authorizes exactly one thing (paying for the order it
+was issued for) for exactly as long as the TTL allows.
+
+## Alternatives considered
+
+- **No auth at all (rely on `orderId` obscurity):** rejected — a UUID isn't
+  a secret, and the issue explicitly calls this out as a real gap ("this
+  endpoint isn't wide open").
+- **Full diner accounts (email/phone + password or OTP):** far more than a
+  QR-code, walk-up checkout flow needs, and a much larger, separate feature
+  with its own security surface (credential storage, account recovery,
+  etc.) — out of scope for a payment-initiation issue.
+- **Reusing the staff `JwtAuthGuard`/`AdminUser`:** would require creating a
+  fake `AdminUser` row per diner or per order, conflating two very
+  different identity concepts and bloating the admin-user table with
+  non-staff rows.
+
+## Consequences
+
+- `AuthModule` now exports `JwtModule` (previously module-local) so
+  `OrdersModule` — which already imports `AuthModule` — can mint/verify
+  checkout tokens with the same `JWT_SECRET` without a second registration.
+- The QR-code generation/printing flow itself (turning a checkout-token
+  response into an actual scannable code) is a frontend concern, not
+  addressed here.
+- If a genuine multi-session diner identity product need emerges later
+  (order history, saved payment methods, etc.), that is a new ADR — this
+  decision should not be stretched to cover it.


### PR DESCRIPTION
## Summary
- Adds `POST /payments/stellar/initiate` and `POST /payments/stellar/:paymentId/submit-signed`, non-custodially building an unsigned Stellar payment transaction and accepting the diner-signed envelope back for submission (per ADR 0001).
- Adds a short-lived, order-scoped diner **checkout token** (ADR 0002, `docs/adr/0002-diner-checkout-authentication.md`) distinct from staff JWT auth, issued via a new staff-gated `GET /orders/:orderId/checkout-token` endpoint and verified by a new `DinerCheckoutGuard`. The payments endpoints are `@Public()` + guarded by this token instead of the global staff `JwtAuthGuard`.
- Adds `SequenceAllocator`, an in-process, per-account-serialized sequence-number allocator, since Horizon sequence numbers only advance on-ledger and two payment builds issued back-to-back for the same source account would otherwise read the same stale value.
- Adds `mapHorizonSubmissionError` plus typed `PaymentError` subclasses (`InsufficientBalanceError`, `MissingTrustlineError`, `SequenceConflictError`, `MalformedPaymentRequestError`, `IdempotencyConflictError`, `RestaurantWalletNotConfiguredError`) so a rejected submission surfaces a structured, distinguishable error instead of a generic 500.
- Idempotency is enforced both by an initial lookup and by the DB unique constraint on `Payment.idempotencyKey` (#312), so two concurrent requests with the same key resolve to the same payment rather than creating a duplicate.
- Adds `Restaurant.stellarWalletAddress` (nullable — initiation is rejected with a structured error when unset) and `Payment.failureReason`.

## Test plan
- [x] `npm run build`
- [x] `npm run lint` (scoped to changed files, then full repo - 0 errors, only pre-existing repo-wide CRLF warnings)
- [x] `npm run test` - all suites pass, including new specs: `sequence-allocator.service.spec.ts` (concurrency/serialization + invalidate), `checkout-token.service.spec.ts`, `diner-checkout.guard.spec.ts`, and `payments.service.spec.ts` (idempotency replay, concurrent-insert race via simulated DB unique-violation, sequence contention, structured error mapping for insufficient balance / sequence conflict)

Closes #313