### PR TITLE
[Payment] Transaction confirmation, status tracking, and reconciliation

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ScheduleModule } from '@nestjs/schedule';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { APP_GUARD } from '@nestjs/core';
 import { ThrottlerGuard } from '@nestjs/throttler';
@@ -19,6 +20,8 @@ import { RolesGuard } from './common/guards/roles.guard';
       isGlobal: true,
       envFilePath: '.env',
     }),
+    // Powers PaymentReconciliationService's @Cron job (issue #314).
+    ScheduleModule.forRoot(),
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/backend/src/modules/payments/errors/horizon-error-mapper.ts
+++ b/backend/src/modules/payments/errors/horizon-error-mapper.ts
@@ -73,3 +73,19 @@ export function mapHorizonSubmissionError(error: unknown): PaymentError {
     error instanceof Error ? error.message : String(error),
   );
 }
+
+/**
+ * Distinguishes "Horizon told us definitively no" (a structured rejection,
+ * or a confirmed not-found account) from an ambiguous network/timeout
+ * error where we genuinely don't know whether the transaction was applied
+ * (issue #314 edge case). Only a definitive rejection justifies marking a
+ * Payment FAILED immediately from the submit call itself — an ambiguous
+ * error must leave the payment SUBMITTED (it already carries a locally-
+ * computed hash) for PaymentReconciliationService to resolve later by
+ * independently checking Horizon.
+ */
+export function isDefinitiveHorizonRejection(error: unknown): boolean {
+  const data = (error as { response?: { data?: unknown } } | undefined)
+    ?.response?.data;
+  return isTransactionFailedData(data) || error instanceof NotFoundError;
+}

--- a/backend/src/modules/payments/payment-reconciliation.service.spec.ts
+++ b/backend/src/modules/payments/payment-reconciliation.service.spec.ts
@@ -1,0 +1,229 @@
+import { NotFoundError } from '@stellar/stellar-sdk';
+import { PaymentReconciliationService } from './payment-reconciliation.service';
+import { Payment, PaymentStatus } from './payment.entity';
+
+type MockRepository = {
+  find: jest.Mock;
+  findOne: jest.Mock;
+  save: jest.Mock;
+};
+
+function makeRepository(): MockRepository {
+  return {
+    find: jest.fn(),
+    findOne: jest.fn(),
+    save: jest.fn(async (entity) => entity),
+  };
+}
+
+function makePayment(overrides: Partial<Payment> = {}): Payment {
+  const now = new Date();
+  return {
+    id: 'payment-1',
+    orderId: 'order-1',
+    sourceAccount: 'GSOURCE...',
+    destinationAccount: 'GDEST...',
+    asset: 'XLM',
+    amount: 10,
+    status: PaymentStatus.SUBMITTED,
+    stellarTxHash: 'tx-hash-1',
+    horizonEnvelopeXdr: 'envelope',
+    confirmedAt: null,
+    failureReason: null,
+    expiresAt: new Date(now.getTime() + 60_000),
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  } as Payment;
+}
+
+describe('PaymentReconciliationService', () => {
+  let paymentRepository: MockRepository;
+  let orderRepository: MockRepository;
+  let stellarService: { fetchTransaction: jest.Mock };
+  let paymentsGateway: { emitPaymentStatusChanged: jest.Mock };
+  let service: PaymentReconciliationService;
+
+  beforeEach(() => {
+    paymentRepository = makeRepository();
+    orderRepository = makeRepository();
+    stellarService = { fetchTransaction: jest.fn() };
+    paymentsGateway = { emitPaymentStatusChanged: jest.fn() };
+
+    orderRepository.findOne.mockResolvedValue({
+      id: 'order-1',
+      restaurantId: 'restaurant-1',
+    });
+
+    service = new PaymentReconciliationService(
+      paymentRepository as any,
+      orderRepository as any,
+      stellarService as any,
+      paymentsGateway as any,
+    );
+  });
+
+  describe('reconcile — resolving a SUBMITTED payment by hash', () => {
+    it('confirms a payment once Horizon reports the transaction successful', async () => {
+      const payment = makePayment();
+      paymentRepository.find
+        .mockResolvedValueOnce([payment]) // SUBMITTED batch
+        .mockResolvedValueOnce([]); // expireStale batch
+      stellarService.fetchTransaction.mockResolvedValueOnce({
+        hash: 'tx-hash-1',
+        successful: true,
+      });
+
+      const summary = await service.reconcile();
+
+      expect(summary.confirmed).toBe(1);
+      expect(paymentRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: PaymentStatus.CONFIRMED }),
+      );
+      expect(paymentsGateway.emitPaymentStatusChanged).toHaveBeenCalledWith(
+        'restaurant-1',
+        expect.objectContaining({
+          paymentId: 'payment-1',
+          status: PaymentStatus.CONFIRMED,
+        }),
+      );
+    });
+
+    it('marks a payment FAILED when Horizon reports the on-ledger transaction unsuccessful', async () => {
+      const payment = makePayment();
+      paymentRepository.find
+        .mockResolvedValueOnce([payment])
+        .mockResolvedValueOnce([]);
+      stellarService.fetchTransaction.mockResolvedValueOnce({
+        hash: 'tx-hash-1',
+        successful: false,
+      });
+
+      const summary = await service.reconcile();
+
+      expect(summary.failed).toBe(1);
+      expect(paymentRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: PaymentStatus.FAILED }),
+      );
+    });
+
+    it('leaves the payment SUBMITTED when Horizon has no record yet (propagation delay), not a failure', async () => {
+      const payment = makePayment();
+      paymentRepository.find
+        .mockResolvedValueOnce([payment])
+        .mockResolvedValueOnce([]);
+      stellarService.fetchTransaction.mockRejectedValueOnce(
+        new NotFoundError('not found', {}),
+      );
+
+      const summary = await service.reconcile();
+
+      expect(summary.stillPending).toBe(1);
+      expect(paymentRepository.save).not.toHaveBeenCalled();
+      expect(paymentsGateway.emitPaymentStatusChanged).not.toHaveBeenCalled();
+    });
+
+    it('leaves the payment SUBMITTED on a transient (non-NotFound) Horizon error, retried next tick', async () => {
+      const payment = makePayment();
+      paymentRepository.find
+        .mockResolvedValueOnce([payment])
+        .mockResolvedValueOnce([]);
+      stellarService.fetchTransaction.mockRejectedValueOnce(
+        new Error('ECONNRESET'),
+      );
+
+      const summary = await service.reconcile();
+
+      expect(summary.stillPending).toBe(1);
+      expect(paymentRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('is safe to run twice: a confirmed payment is not reprocessed on the next pass (idempotent)', async () => {
+      const payment = makePayment();
+      paymentRepository.find
+        .mockResolvedValueOnce([payment])
+        .mockResolvedValueOnce([]);
+      stellarService.fetchTransaction.mockResolvedValueOnce({
+        hash: 'tx-hash-1',
+        successful: true,
+      });
+
+      await service.reconcile();
+
+      // Second pass: the payment is no longer SUBMITTED, so the query for
+      // SUBMITTED payments naturally excludes it — simulated here by
+      // returning an empty batch, since paymentRepository is mocked.
+      paymentRepository.find
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+      const secondSummary = await service.reconcile();
+
+      expect(secondSummary.confirmed).toBe(0);
+      expect(stellarService.fetchTransaction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('reconcile — expiry', () => {
+    it('expires a SUBMITTED payment past its timebounds that Horizon still has no record of', async () => {
+      const now = new Date();
+      const payment = makePayment({
+        expiresAt: new Date(now.getTime() - 1000),
+      });
+      paymentRepository.find
+        .mockResolvedValueOnce([]) // no SUBMITTED-batch candidates (already past due, handled by expiry loop)
+        .mockResolvedValueOnce([payment]); // expireStale batch
+      stellarService.fetchTransaction.mockRejectedValueOnce(
+        new NotFoundError('not found', {}),
+      );
+
+      const summary = await service.reconcile(now);
+
+      expect(summary.expired).toBe(1);
+      expect(paymentRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: PaymentStatus.EXPIRED }),
+      );
+    });
+
+    it('expires a PENDING payment past its timebounds (never even submitted)', async () => {
+      const now = new Date();
+      const payment = makePayment({
+        status: PaymentStatus.PENDING,
+        stellarTxHash: null,
+        expiresAt: new Date(now.getTime() - 1000),
+      });
+      paymentRepository.find
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([payment]);
+
+      const summary = await service.reconcile(now);
+
+      expect(summary.expired).toBe(1);
+      expect(stellarService.fetchTransaction).not.toHaveBeenCalled();
+      expect(paymentRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: PaymentStatus.EXPIRED }),
+      );
+    });
+
+    it('does not expire a SUBMITTED payment that confirms in the same pass its deadline passed', async () => {
+      const now = new Date();
+      const payment = makePayment({
+        expiresAt: new Date(now.getTime() - 1000),
+      });
+      paymentRepository.find
+        .mockResolvedValueOnce([]) // not in the SUBMITTED batch (already past due-window handling below)
+        .mockResolvedValueOnce([payment]); // picked up by expireStale instead
+      stellarService.fetchTransaction.mockResolvedValueOnce({
+        hash: 'tx-hash-1',
+        successful: true,
+      });
+
+      const summary = await service.reconcile(now);
+
+      expect(summary.confirmed).toBe(1);
+      expect(summary.expired).toBe(0);
+      expect(paymentRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: PaymentStatus.CONFIRMED }),
+      );
+    });
+  });
+});

--- a/backend/src/modules/payments/payment-reconciliation.service.ts
+++ b/backend/src/modules/payments/payment-reconciliation.service.ts
@@ -1,0 +1,211 @@
+// backend/src/modules/payments/payment-reconciliation.service.ts
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { LessThan, Repository } from 'typeorm';
+import { NotFoundError } from '@stellar/stellar-sdk';
+import { Order } from '../orders/order.entity';
+import { Payment, PaymentStatus } from './payment.entity';
+import { StellarService } from './stellar.service';
+import { PaymentsGateway } from './payments.gateway';
+import { assertValidTransition } from './payment-state-machine';
+
+export interface ReconciliationSummary {
+  checked: number;
+  confirmed: number;
+  failed: number;
+  stillPending: number;
+  expired: number;
+}
+
+/**
+ * Independent-verification worker and safety net (issue #314). Two jobs:
+ *
+ *  1. For every SUBMITTED payment, ask Horizon directly (by hash) whether
+ *     it actually landed — this is the ONLY path that may set CONFIRMED.
+ *     Runs on a short interval so confirmation latency stays close to
+ *     Stellar's real ~3-5s settlement time. (A streaming/SSE fast path is
+ *     a documented follow-up — see the class-level note below — polling
+ *     alone already satisfies this issue's correctness requirements.)
+ *  2. Expires PENDING/SUBMITTED payments whose transaction timebounds have
+ *     passed without a confirmation ever landing — explicitly EXPIRED, not
+ *     FAILED, so the API/UI can tell "never charged" apart from "charge
+ *     attempted and rejected."
+ *
+ * Streaming note: Horizon's SSE stream (`server.transactions().stream()`)
+ * would get confirmations closer to the moment they land instead of
+ * waiting for the next poll tick, but a stream subscription needs its own
+ * reconnect/backfill handling to be safe across a service restart — since
+ * this poll already re-checks every SUBMITTED payment on every tick
+ * (including ones a stream would have missed while disconnected), it's the
+ * correctness-bearing mechanism either way. Layering a stream on top as a
+ * pure latency optimization is a reasonable follow-up, not required for
+ * this issue's acceptance criteria.
+ */
+@Injectable()
+export class PaymentReconciliationService {
+  private readonly logger = new Logger(PaymentReconciliationService.name);
+
+  constructor(
+    @InjectRepository(Payment)
+    private readonly paymentRepository: Repository<Payment>,
+    @InjectRepository(Order)
+    private readonly orderRepository: Repository<Order>,
+    private readonly stellarService: StellarService,
+    private readonly paymentsGateway: PaymentsGateway,
+  ) {}
+
+  @Cron(CronExpression.EVERY_10_SECONDS)
+  async handleCron(): Promise<void> {
+    const summary = await this.reconcile();
+    if (summary.checked > 0 || summary.expired > 0) {
+      this.logger.log(`Reconciliation pass: ${JSON.stringify(summary)}`);
+    }
+  }
+
+  async reconcile(now: Date = new Date()): Promise<ReconciliationSummary> {
+    const summary: ReconciliationSummary = {
+      checked: 0,
+      confirmed: 0,
+      failed: 0,
+      stillPending: 0,
+      expired: 0,
+    };
+
+    const submitted = await this.paymentRepository.find({
+      where: { status: PaymentStatus.SUBMITTED },
+    });
+
+    for (const payment of submitted) {
+      summary.checked++;
+      const resolved = await this.confirmOne(payment, now);
+      switch (resolved.status) {
+        case PaymentStatus.CONFIRMED:
+          summary.confirmed++;
+          break;
+        case PaymentStatus.FAILED:
+          summary.failed++;
+          break;
+        case PaymentStatus.EXPIRED:
+          summary.expired++;
+          break;
+        default:
+          summary.stillPending++;
+      }
+    }
+
+    await this.expireStale(now, summary);
+
+    return summary;
+  }
+
+  /**
+   * The only place allowed to set CONFIRMED — always by independently
+   * querying Horizon for the payment's own `stellarTxHash`, never assumed
+   * from the earlier submit call (issue #314's central requirement).
+   */
+  private async confirmOne(payment: Payment, now: Date): Promise<Payment> {
+    if (!payment.stellarTxHash) {
+      // Nothing to verify yet — shouldn't normally happen for a SUBMITTED
+      // payment, but never let a malformed row loop forever; expiry still
+      // applies to it via expireStale.
+      return payment;
+    }
+
+    try {
+      const record = await this.stellarService.fetchTransaction(
+        payment.stellarTxHash,
+      );
+
+      if (record.successful) {
+        assertValidTransition(payment.status, PaymentStatus.CONFIRMED);
+        payment.status = PaymentStatus.CONFIRMED;
+        payment.confirmedAt = now;
+      } else {
+        assertValidTransition(payment.status, PaymentStatus.FAILED);
+        payment.status = PaymentStatus.FAILED;
+        payment.failureReason = 'SUBMISSION_FAILED';
+      }
+
+      const saved = await this.paymentRepository.save(payment);
+      this.logger.log(
+        `Payment ${saved.id} reconciled to ${saved.status} (tx ${payment.stellarTxHash})`,
+      );
+      await this.emitStatusChanged(saved);
+      return saved;
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        // Horizon has no record of it yet — this is expected for a short
+        // window after submission (propagation delay), not a failure.
+        // Bounded by expireStale() once the transaction's own timebounds
+        // pass without ever landing.
+        return payment;
+      }
+
+      this.logger.warn(
+        `Reconciliation check failed for payment ${payment.id}: ` +
+          (error instanceof Error ? error.message : String(error)),
+      );
+      return payment;
+    }
+  }
+
+  /**
+   * Payments whose Stellar timebounds have passed without ever being
+   * confirmed — including ones still PENDING (never even submitted) — are
+   * marked EXPIRED rather than FAILED, so it's clear the customer was
+   * never charged. A SUBMITTED payment is given one last direct check
+   * first, in case it confirmed in the same instant its deadline passed.
+   */
+  private async expireStale(
+    now: Date,
+    summary: ReconciliationSummary,
+  ): Promise<void> {
+    const stale = await this.paymentRepository.find({
+      where: [
+        { status: PaymentStatus.PENDING, expiresAt: LessThan(now) },
+        { status: PaymentStatus.SUBMITTED, expiresAt: LessThan(now) },
+      ],
+    });
+
+    for (const payment of stale) {
+      if (payment.status === PaymentStatus.SUBMITTED) {
+        const resolved = await this.confirmOne(payment, now);
+        if (resolved.status === PaymentStatus.CONFIRMED) {
+          summary.confirmed++;
+          continue;
+        }
+        if (resolved.status === PaymentStatus.FAILED) {
+          summary.failed++;
+          continue;
+        }
+        // Still SUBMITTED — Horizon has no record and never will in time.
+      }
+
+      assertValidTransition(payment.status, PaymentStatus.EXPIRED);
+      payment.status = PaymentStatus.EXPIRED;
+      const saved = await this.paymentRepository.save(payment);
+      this.logger.warn(
+        `Payment ${saved.id} expired without confirmation (timebounds passed)`,
+      );
+      await this.emitStatusChanged(saved);
+      summary.expired++;
+    }
+  }
+
+  private async emitStatusChanged(payment: Payment): Promise<void> {
+    const order = await this.orderRepository.findOne({
+      where: { id: payment.orderId },
+    });
+    if (!order) return;
+
+    this.paymentsGateway.emitPaymentStatusChanged(order.restaurantId, {
+      paymentId: payment.id,
+      orderId: payment.orderId,
+      status: payment.status,
+      stellarTxHash: payment.stellarTxHash,
+      failureReason: payment.failureReason,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+}

--- a/backend/src/modules/payments/payment-state-machine.spec.ts
+++ b/backend/src/modules/payments/payment-state-machine.spec.ts
@@ -1,0 +1,57 @@
+import { UnprocessableEntityException } from '@nestjs/common';
+import { assertValidTransition, canTransition } from './payment-state-machine';
+import { PaymentStatus } from './payment.entity';
+
+describe('payment state machine', () => {
+  const ALL_STATUSES = Object.values(PaymentStatus);
+
+  const VALID_TRANSITIONS: [PaymentStatus, PaymentStatus][] = [
+    [PaymentStatus.PENDING, PaymentStatus.SUBMITTED],
+    [PaymentStatus.PENDING, PaymentStatus.FAILED],
+    [PaymentStatus.PENDING, PaymentStatus.EXPIRED],
+    [PaymentStatus.SUBMITTED, PaymentStatus.CONFIRMED],
+    [PaymentStatus.SUBMITTED, PaymentStatus.FAILED],
+    [PaymentStatus.SUBMITTED, PaymentStatus.EXPIRED],
+  ];
+
+  it.each(VALID_TRANSITIONS)('allows %s -> %s', (from, to) => {
+    expect(canTransition(from, to)).toBe(true);
+    expect(() => assertValidTransition(from, to)).not.toThrow();
+  });
+
+  const validSet = new Set(
+    VALID_TRANSITIONS.map(([from, to]) => `${from}->${to}`),
+  );
+
+  const illegalTransitions = ALL_STATUSES.flatMap((from) =>
+    ALL_STATUSES.filter((to) => !validSet.has(`${from}->${to}`)).map(
+      (to): [PaymentStatus, PaymentStatus] => [from, to],
+    ),
+  );
+
+  it.each(illegalTransitions)('rejects %s -> %s', (from, to) => {
+    expect(canTransition(from, to)).toBe(false);
+    expect(() => assertValidTransition(from, to)).toThrow(
+      UnprocessableEntityException,
+    );
+  });
+
+  it('never allows confirmed to be reached directly from pending', () => {
+    expect(canTransition(PaymentStatus.PENDING, PaymentStatus.CONFIRMED)).toBe(
+      false,
+    );
+  });
+
+  it('has no outgoing transitions from any terminal status', () => {
+    const terminal = [
+      PaymentStatus.CONFIRMED,
+      PaymentStatus.FAILED,
+      PaymentStatus.EXPIRED,
+    ];
+    for (const status of terminal) {
+      for (const to of ALL_STATUSES) {
+        expect(canTransition(status, to)).toBe(false);
+      }
+    }
+  });
+});

--- a/backend/src/modules/payments/payment-state-machine.ts
+++ b/backend/src/modules/payments/payment-state-machine.ts
@@ -1,0 +1,41 @@
+// backend/src/modules/payments/payment-state-machine.ts
+import { UnprocessableEntityException } from '@nestjs/common';
+import { PaymentStatus } from './payment.entity';
+
+/**
+ * The single source of truth for legal Payment status transitions (issue
+ * #314): `pending -> submitted -> confirmed | failed | expired`.
+ * `confirmed` is reachable only from `submitted` — never set directly on a
+ * successful submit call, only after PaymentReconciliationService
+ * independently verifies the transaction against Horizon by hash.
+ */
+const ALLOWED_TRANSITIONS: Record<PaymentStatus, PaymentStatus[]> = {
+  [PaymentStatus.PENDING]: [
+    PaymentStatus.SUBMITTED,
+    PaymentStatus.FAILED,
+    PaymentStatus.EXPIRED,
+  ],
+  [PaymentStatus.SUBMITTED]: [
+    PaymentStatus.CONFIRMED,
+    PaymentStatus.FAILED,
+    PaymentStatus.EXPIRED,
+  ],
+  [PaymentStatus.CONFIRMED]: [],
+  [PaymentStatus.FAILED]: [],
+  [PaymentStatus.EXPIRED]: [],
+};
+
+export function canTransition(from: PaymentStatus, to: PaymentStatus): boolean {
+  return ALLOWED_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+export function assertValidTransition(
+  from: PaymentStatus,
+  to: PaymentStatus,
+): void {
+  if (!canTransition(from, to)) {
+    throw new UnprocessableEntityException(
+      `Illegal payment status transition: ${from} -> ${to}`,
+    );
+  }
+}

--- a/backend/src/modules/payments/payment.entity.ts
+++ b/backend/src/modules/payments/payment.entity.ts
@@ -64,6 +64,13 @@ export class Payment {
   @Column({ type: 'timestamp', nullable: true })
   confirmedAt: Date | null;
 
+  // Mirrors the built transaction's own Stellar timebounds (issue #314) —
+  // once this passes without an independently-verified confirmation, the
+  // reconciliation job marks the payment EXPIRED rather than polling
+  // forever. Set at PENDING-creation time in PaymentsService.initiate().
+  @Column({ type: 'timestamp', nullable: true })
+  expiresAt: Date | null;
+
   // Populated when status transitions to FAILED — a typed PaymentErrorCode
   // (see errors/payment.errors.ts), not a raw Horizon/stack-trace dump, so
   // it's safe to surface back to the diner-facing client.

--- a/backend/src/modules/payments/payments.controller.ts
+++ b/backend/src/modules/payments/payments.controller.ts
@@ -2,6 +2,7 @@
 import {
   Body,
   Controller,
+  Get,
   Param,
   Post,
   Request,
@@ -51,6 +52,18 @@ export class PaymentsController {
       req.checkoutContext.orderId,
       dto,
     );
+  }
+
+  // Reconnect-safe status fetch (issue #314 edge case): a client that
+  // disconnects from the payments WebSocket before the confirmation event
+  // arrives must be able to fetch current status directly instead of
+  // relying solely on the push event.
+  @Get(':paymentId')
+  async findOne(
+    @Request() req: CheckoutRequest,
+    @Param('paymentId') paymentId: string,
+  ) {
+    return this.paymentsService.findOne(paymentId, req.checkoutContext.orderId);
   }
 
   // A valid checkout token only ever authorizes the order it was issued

--- a/backend/src/modules/payments/payments.gateway.ts
+++ b/backend/src/modules/payments/payments.gateway.ts
@@ -1,0 +1,103 @@
+// backend/src/modules/payments/payments.gateway.ts
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import {
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  WebSocketGateway,
+  WebSocketServer,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { PaymentStatus } from './payment.entity';
+
+interface PaymentSocketUser {
+  sub: string;
+  username: string;
+  role: string;
+  restaurantId: string;
+}
+
+export interface PaymentStatusChangedEvent {
+  paymentId: string;
+  orderId: string;
+  status: PaymentStatus;
+  stellarTxHash: string | null;
+  failureReason: string | null;
+  updatedAt: string;
+}
+
+function restaurantRoom(restaurantId: string): string {
+  return `restaurant:${restaurantId}`;
+}
+
+// Sibling to OrdersGateway (issue #314), following its connection/auth/room
+// pattern exactly rather than sharing its namespace — a payment confirming
+// asynchronously (independent of any HTTP response in flight) shouldn't
+// share a connection lifecycle with order-status events.
+@WebSocketGateway({
+  namespace: '/payments',
+  cors: {
+    origin: process.env.FRONTEND_URL || 'http://localhost:3000',
+    credentials: true,
+  },
+})
+export class PaymentsGateway
+  implements OnGatewayConnection, OnGatewayDisconnect
+{
+  private readonly logger = new Logger(PaymentsGateway.name);
+
+  @WebSocketServer()
+  server: Server;
+
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  handleConnection(client: Socket): void {
+    const token = client.handshake.auth?.token as string | undefined;
+
+    if (!token) {
+      this.rejectConnection(client, 'Missing authentication token');
+      return;
+    }
+
+    try {
+      const payload = this.jwtService.verify<PaymentSocketUser>(token, {
+        secret: this.configService.get('JWT_SECRET') || 'your-secret-key',
+      });
+
+      if (!payload.restaurantId) {
+        this.rejectConnection(client, 'Token missing restaurant scope');
+        return;
+      }
+
+      client.data.user = payload;
+      void client.join(restaurantRoom(payload.restaurantId));
+      this.logger.log(
+        `Client ${client.id} connected (restaurant ${payload.restaurantId})`,
+      );
+    } catch {
+      this.rejectConnection(client, 'Invalid or expired token');
+    }
+  }
+
+  handleDisconnect(client: Socket): void {
+    this.logger.log(`Client ${client.id} disconnected`);
+  }
+
+  private rejectConnection(client: Socket, reason: string): void {
+    client.emit('connection:error', { message: reason });
+    client.disconnect(true);
+  }
+
+  emitPaymentStatusChanged(
+    restaurantId: string,
+    event: PaymentStatusChangedEvent,
+  ): void {
+    this.server
+      .to(restaurantRoom(restaurantId))
+      .emit('payment:status_changed', event);
+  }
+}

--- a/backend/src/modules/payments/payments.module.ts
+++ b/backend/src/modules/payments/payments.module.ts
@@ -8,15 +8,27 @@ import { StellarService } from './stellar.service';
 import { SequenceAllocator } from './sequence-allocator.service';
 import { PaymentsService } from './payments.service';
 import { PaymentsController } from './payments.controller';
+import { PaymentsGateway } from './payments.gateway';
+import { PaymentReconciliationService } from './payment-reconciliation.service';
 import { OrdersModule } from '../orders/orders.module';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Payment, Order, Restaurant]),
     OrdersModule,
+    // PaymentsGateway needs JwtService directly — OrdersModule imports
+    // AuthModule but doesn't re-export it, so it must be imported here too.
+    AuthModule,
   ],
   controllers: [PaymentsController],
-  providers: [StellarService, SequenceAllocator, PaymentsService],
+  providers: [
+    StellarService,
+    SequenceAllocator,
+    PaymentsService,
+    PaymentsGateway,
+    PaymentReconciliationService,
+  ],
   exports: [StellarService],
 })
 export class PaymentsModule {}

--- a/backend/src/modules/payments/payments.service.spec.ts
+++ b/backend/src/modules/payments/payments.service.spec.ts
@@ -35,11 +35,20 @@ describe('PaymentsService', () => {
   let paymentRepository: MockRepository;
   let orderRepository: MockRepository;
   let restaurantRepository: MockRepository;
-  let stellarService: { buildPaymentTransaction: jest.Mock; submitTransaction: jest.Mock };
+  let stellarService: {
+    buildPaymentTransaction: jest.Mock;
+    submitTransaction: jest.Mock;
+    computeTransactionHash: jest.Mock;
+  };
   let sequenceAllocator: { allocate: jest.Mock; invalidate: jest.Mock };
+  let paymentsGateway: { emitPaymentStatusChanged: jest.Mock };
   let service: PaymentsService;
 
-  const order = { id: 'order-1', restaurantId: 'restaurant-1', orderNumber: 'ORD-1' };
+  const order = {
+    id: 'order-1',
+    restaurantId: 'restaurant-1',
+    orderNumber: 'ORD-1',
+  };
   const restaurant = { id: 'restaurant-1', stellarWalletAddress: 'GDEST...' };
 
   const baseDto = {
@@ -57,11 +66,15 @@ describe('PaymentsService', () => {
     stellarService = {
       buildPaymentTransaction: jest.fn().mockResolvedValue('unsigned-xdr'),
       submitTransaction: jest.fn(),
+      computeTransactionHash: jest
+        .fn()
+        .mockReturnValue('locally-computed-hash'),
     };
     sequenceAllocator = {
       allocate: jest.fn().mockResolvedValue('101'),
       invalidate: jest.fn(),
     };
+    paymentsGateway = { emitPaymentStatusChanged: jest.fn() };
 
     service = new PaymentsService(
       paymentRepository as any,
@@ -69,6 +82,7 @@ describe('PaymentsService', () => {
       restaurantRepository as any,
       stellarService as any,
       sequenceAllocator as any,
+      paymentsGateway as any,
     );
 
     paymentRepository.findOne.mockResolvedValue(null);
@@ -180,7 +194,7 @@ describe('PaymentsService', () => {
   });
 
   describe('submitSigned', () => {
-    it('submits to Horizon and marks the payment confirmed', async () => {
+    it('submits to Horizon and marks the payment SUBMITTED, never CONFIRMED directly', async () => {
       paymentRepository.findOne.mockResolvedValueOnce({
         id: 'payment-1',
         orderId: 'order-1',
@@ -198,15 +212,86 @@ describe('PaymentsService', () => {
 
       expect(result).toEqual({
         paymentId: 'payment-1',
-        status: PaymentStatus.CONFIRMED,
-        stellarTxHash: 'tx-hash-1',
+        status: PaymentStatus.SUBMITTED,
+        stellarTxHash: 'locally-computed-hash',
       });
       expect(paymentRepository.save).toHaveBeenCalledWith(
         expect.objectContaining({
-          status: PaymentStatus.CONFIRMED,
-          stellarTxHash: 'tx-hash-1',
+          status: PaymentStatus.SUBMITTED,
+          stellarTxHash: 'locally-computed-hash',
         }),
       );
+      expect(paymentsGateway.emitPaymentStatusChanged).toHaveBeenCalledWith(
+        'restaurant-1',
+        expect.objectContaining({
+          paymentId: 'payment-1',
+          status: PaymentStatus.SUBMITTED,
+        }),
+      );
+    });
+
+    it('computes and persists the hash locally BEFORE calling Horizon', async () => {
+      paymentRepository.findOne.mockResolvedValueOnce({
+        id: 'payment-1',
+        orderId: 'order-1',
+        sourceAccount: 'GSOURCE...',
+        status: PaymentStatus.PENDING,
+      });
+      stellarService.submitTransaction.mockResolvedValueOnce({
+        hash: 'tx-hash-1',
+        successful: true,
+      });
+
+      await service.submitSigned('payment-1', 'order-1', {
+        signedTransactionXdr: 'signed-xdr',
+      });
+
+      expect(stellarService.computeTransactionHash).toHaveBeenCalledWith(
+        'signed-xdr',
+      );
+    });
+
+    it('leaves the payment SUBMITTED on an ambiguous (network/timeout) submit error, without throwing', async () => {
+      paymentRepository.findOne.mockResolvedValueOnce({
+        id: 'payment-1',
+        orderId: 'order-1',
+        sourceAccount: 'GSOURCE...',
+        status: PaymentStatus.PENDING,
+      });
+      stellarService.submitTransaction.mockRejectedValueOnce(
+        new Error('socket hang up'),
+      );
+
+      const result = await service.submitSigned('payment-1', 'order-1', {
+        signedTransactionXdr: 'signed-xdr',
+      });
+
+      expect(result).toEqual({
+        paymentId: 'payment-1',
+        status: PaymentStatus.SUBMITTED,
+        stellarTxHash: 'locally-computed-hash',
+      });
+      // Only ever saved once — the initial PENDING -> SUBMITTED transition.
+      // An ambiguous error must not also flip it to FAILED.
+      expect(paymentRepository.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('is a no-op replay for an already-submitted payment', async () => {
+      paymentRepository.findOne.mockResolvedValueOnce({
+        id: 'payment-1',
+        orderId: 'order-1',
+        sourceAccount: 'GSOURCE...',
+        status: PaymentStatus.SUBMITTED,
+        stellarTxHash: 'tx-hash-1',
+      });
+
+      const result = await service.submitSigned('payment-1', 'order-1', {
+        signedTransactionXdr: 'signed-xdr',
+      });
+
+      expect(result.status).toBe(PaymentStatus.SUBMITTED);
+      expect(stellarService.submitTransaction).not.toHaveBeenCalled();
+      expect(paymentRepository.save).not.toHaveBeenCalled();
     });
 
     it('is a no-op replay for an already-confirmed payment', async () => {

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -1,21 +1,26 @@
 // backend/src/modules/payments/payments.service.ts
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { QueryFailedError, Repository } from 'typeorm';
 import { Order } from '../orders/order.entity';
 import { Restaurant } from '../restaurant/restaurant.entity';
 import { Payment, PaymentStatus } from './payment.entity';
-import { StellarService } from './stellar.service';
+import { StellarService, TRANSACTION_TIMEOUT_SECONDS } from './stellar.service';
 import { SequenceAllocator } from './sequence-allocator.service';
+import { PaymentsGateway } from './payments.gateway';
 import { InitiatePaymentDto } from './dto/initiate-payment.dto';
 import { SubmitSignedPaymentDto } from './dto/submit-signed-payment.dto';
-import { mapHorizonSubmissionError } from './errors/horizon-error-mapper';
+import {
+  isDefinitiveHorizonRejection,
+  mapHorizonSubmissionError,
+} from './errors/horizon-error-mapper';
 import {
   IdempotencyConflictError,
   MalformedPaymentRequestError,
   RestaurantWalletNotConfiguredError,
   SequenceConflictError,
 } from './errors/payment.errors';
+import { assertValidTransition } from './payment-state-machine';
 
 // Postgres unique_violation — see https://www.postgresql.org/docs/current/errcodes-appendix.html
 const POSTGRES_UNIQUE_VIOLATION = '23505';
@@ -45,6 +50,7 @@ export class PaymentsService {
     private readonly restaurantRepository: Repository<Restaurant>,
     private readonly stellarService: StellarService,
     private readonly sequenceAllocator: SequenceAllocator,
+    private readonly paymentsGateway: PaymentsGateway,
   ) {}
 
   async initiate(dto: InitiatePaymentDto): Promise<InitiatePaymentResult> {
@@ -119,6 +125,7 @@ export class PaymentsService {
       amount: Number(dto.amount),
       status: PaymentStatus.PENDING,
       horizonEnvelopeXdr: unsignedTransactionXdr,
+      expiresAt: new Date(Date.now() + TRANSACTION_TIMEOUT_SECONDS * 1000),
     });
 
     try {
@@ -153,6 +160,14 @@ export class PaymentsService {
     };
   }
 
+  /**
+   * `CONFIRMED` is never set here — only PaymentReconciliationService may
+   * set it, and only after independently verifying the transaction against
+   * Horizon by hash (issue #314). This method's job is just: attempt
+   * submission, and record enough (the locally-computed hash) that the
+   * outcome can always be resolved later, even if the submit call itself
+   * errors ambiguously.
+   */
   async submitSigned(
     paymentId: string,
     orderId: string,
@@ -165,13 +180,10 @@ export class PaymentsService {
       throw new MalformedPaymentRequestError({ reason: 'unknown paymentId' });
     }
 
-    // Already-terminal payments are a no-op replay, not a resubmission —
-    // the client may retry after a dropped HTTP response even though the
-    // first submission already reached Horizon.
-    if (
-      payment.status === PaymentStatus.SUBMITTED ||
-      payment.status === PaymentStatus.CONFIRMED
-    ) {
+    // Already-terminal or already-submitted payments are a no-op replay,
+    // not a resubmission — the client may retry after a dropped HTTP
+    // response even though the first submission already reached Horizon.
+    if (payment.status !== PaymentStatus.PENDING) {
       return {
         paymentId: payment.id,
         status: payment.status,
@@ -179,35 +191,88 @@ export class PaymentsService {
       };
     }
 
+    // Computed locally, before ever calling Horizon — if the submit call
+    // below throws ambiguously (timeout, dropped connection), we still
+    // know which hash to independently verify later instead of having no
+    // way to look the transaction up at all.
+    const stellarTxHash = this.stellarService.computeTransactionHash(
+      dto.signedTransactionXdr,
+    );
+    assertValidTransition(payment.status, PaymentStatus.SUBMITTED);
+    payment.status = PaymentStatus.SUBMITTED;
+    payment.stellarTxHash = stellarTxHash;
+    payment.horizonEnvelopeXdr = dto.signedTransactionXdr;
+    await this.paymentRepository.save(payment);
+    await this.emitStatusChanged(payment);
+
     try {
-      const response = await this.stellarService.submitTransaction(
-        dto.signedTransactionXdr,
-      );
-
-      payment.status = PaymentStatus.CONFIRMED;
-      payment.stellarTxHash = response.hash;
-      payment.horizonEnvelopeXdr = dto.signedTransactionXdr;
-      payment.confirmedAt = new Date();
-      await this.paymentRepository.save(payment);
-
+      await this.stellarService.submitTransaction(dto.signedTransactionXdr);
+      // A clean response here means Horizon accepted it — but per #314,
+      // `confirmed` is only ever set by independent by-hash verification,
+      // which PaymentReconciliationService performs on its own schedule.
       return {
         paymentId: payment.id,
         status: payment.status,
         stellarTxHash: payment.stellarTxHash,
       };
     } catch (error) {
+      if (!isDefinitiveHorizonRejection(error)) {
+        // Ambiguous: we don't know whether Horizon actually applied it.
+        // Leave the payment SUBMITTED — reconciliation resolves it from
+        // here, by hash, rather than risk marking a possibly-successful
+        // payment FAILED.
+        this.logger.warn(
+          `Ambiguous submit error for payment ${payment.id} (hash ${stellarTxHash}); ` +
+            'leaving SUBMITTED for reconciliation to resolve: ' +
+            (error instanceof Error ? error.message : String(error)),
+        );
+        return {
+          paymentId: payment.id,
+          status: payment.status,
+          stellarTxHash: payment.stellarTxHash,
+        };
+      }
+
       const mapped = mapHorizonSubmissionError(error);
 
       if (mapped instanceof SequenceConflictError) {
         this.sequenceAllocator.invalidate(payment.sourceAccount);
       }
 
+      assertValidTransition(payment.status, PaymentStatus.FAILED);
       payment.status = PaymentStatus.FAILED;
       payment.failureReason = mapped.code;
       await this.paymentRepository.save(payment);
+      await this.emitStatusChanged(payment);
 
       throw mapped;
     }
+  }
+
+  async findOne(paymentId: string, orderId: string): Promise<Payment> {
+    const payment = await this.paymentRepository.findOne({
+      where: { id: paymentId, orderId },
+    });
+    if (!payment) {
+      throw new NotFoundException('Payment not found');
+    }
+    return payment;
+  }
+
+  private async emitStatusChanged(payment: Payment): Promise<void> {
+    const order = await this.orderRepository.findOne({
+      where: { id: payment.orderId },
+    });
+    if (!order) return;
+
+    this.paymentsGateway.emitPaymentStatusChanged(order.restaurantId, {
+      paymentId: payment.id,
+      orderId: payment.orderId,
+      status: payment.status,
+      stellarTxHash: payment.stellarTxHash,
+      failureReason: payment.failureReason,
+      updatedAt: new Date().toISOString(),
+    });
   }
 
   private isUniqueViolation(error: unknown): boolean {

--- a/backend/src/modules/payments/stellar.service.spec.ts
+++ b/backend/src/modules/payments/stellar.service.spec.ts
@@ -9,6 +9,7 @@ const destinationKeypair = Keypair.random();
 const mockLoadAccount = jest.fn();
 const mockFetchBaseFee = jest.fn();
 const mockSubmitTransaction = jest.fn();
+const mockGetTransaction = jest.fn();
 
 jest.mock('@stellar/stellar-sdk', () => {
   const actual = jest.requireActual('@stellar/stellar-sdk');
@@ -20,6 +21,11 @@ jest.mock('@stellar/stellar-sdk', () => {
         loadAccount: mockLoadAccount,
         fetchBaseFee: mockFetchBaseFee,
         submitTransaction: mockSubmitTransaction,
+        transactions: jest.fn().mockImplementation(() => ({
+          transaction: jest.fn().mockImplementation((hash: string) => ({
+            call: () => mockGetTransaction(hash),
+          })),
+        })),
       })),
     },
   };
@@ -176,6 +182,55 @@ describe('StellarService', () => {
 
       expect(mockSubmitTransaction).toHaveBeenCalledTimes(1);
       expect(result).toEqual({ hash: 'fake-hash', successful: true });
+    });
+  });
+
+  describe('computeTransactionHash', () => {
+    it('computes a deterministic hex hash locally, without any network call', async () => {
+      const service = readyService();
+      mockLoadAccount.mockResolvedValueOnce(
+        new Account(sourceKeypair.publicKey(), '100'),
+      );
+      mockFetchBaseFee.mockResolvedValueOnce(100);
+
+      const xdr = await service.buildPaymentTransaction({
+        sourceAccount: sourceKeypair.publicKey(),
+        destinationAccount: destinationKeypair.publicKey(),
+        assetCode: 'XLM',
+        amount: '1.0000000',
+      });
+
+      const hash = service.computeTransactionHash(xdr);
+
+      expect(hash).toMatch(/^[0-9a-f]{64}$/);
+      expect(mockSubmitTransaction).not.toHaveBeenCalled();
+      // Deterministic: computing it again from the same XDR yields the same hash.
+      expect(service.computeTransactionHash(xdr)).toBe(hash);
+    });
+  });
+
+  describe('fetchTransaction', () => {
+    it('delegates to Horizon transactions().transaction(hash).call()', async () => {
+      const service = readyService();
+      mockGetTransaction.mockResolvedValueOnce({
+        hash: 'abc123',
+        successful: true,
+      });
+
+      const result = await service.fetchTransaction('abc123');
+
+      expect(mockGetTransaction).toHaveBeenCalledWith('abc123');
+      expect(result).toEqual({ hash: 'abc123', successful: true });
+    });
+
+    it('propagates a rejection (e.g. NotFoundError) to the caller', async () => {
+      const service = readyService();
+      const notFound = new Error('not found');
+      mockGetTransaction.mockRejectedValueOnce(notFound);
+
+      await expect(service.fetchTransaction('missing-hash')).rejects.toThrow(
+        'not found',
+      );
     });
   });
 });

--- a/backend/src/modules/payments/stellar.service.ts
+++ b/backend/src/modules/payments/stellar.service.ts
@@ -32,6 +32,10 @@ export interface BuildPaymentTransactionParams {
   sequenceOverride?: string;
 }
 
+// Shared between the transaction builder's own timeout and the Payment's
+// expiresAt bookkeeping (issue #314) so the two never drift apart.
+export const TRANSACTION_TIMEOUT_SECONDS = 180;
+
 /**
  * Thin, testable wrapper around @stellar/stellar-sdk's Horizon.Server.
  * No business logic lives here (idempotency, persistence, retry policy) —
@@ -122,7 +126,7 @@ export class StellarService implements OnModuleInit {
         }),
       )
       .addMemo(params.memo ? Memo.text(params.memo) : Memo.none())
-      .setTimeout(180)
+      .setTimeout(TRANSACTION_TIMEOUT_SECONDS)
       .build();
 
     return transaction.toXDR();
@@ -137,5 +141,34 @@ export class StellarService implements OnModuleInit {
       this.networkPassphrase,
     );
     return this.server.submitTransaction(transaction);
+  }
+
+  /**
+   * Computes a transaction's hash locally from its (signed or unsigned)
+   * XDR — deterministic, no network call. Used to record a Payment's
+   * `stellarTxHash` BEFORE attempting submission (issue #314): if the
+   * submit call itself errors ambiguously (timeout, dropped connection),
+   * we still know which hash to independently verify later, rather than
+   * having no way to look the transaction up at all.
+   */
+  computeTransactionHash(transactionXdr: string): string {
+    const transaction = TransactionBuilder.fromXDR(
+      transactionXdr,
+      this.networkPassphrase,
+    );
+    return transaction.hash().toString('hex');
+  }
+
+  /**
+   * Independently verifies a transaction against Horizon by hash — the
+   * only thing allowed to justify a CONFIRMED status (issue #314). Throws
+   * NotFoundError (re-exported by the caller's check) when the ledger has
+   * no record of it yet, which is expected for a few seconds after
+   * submission (propagation delay), not necessarily a failure.
+   */
+  async fetchTransaction(
+    hash: string,
+  ): Promise<Horizon.ServerApi.TransactionRecord> {
+    return this.server.transactions().transaction(hash).call();
   }
 }

--- a/docs/adr/0003-payment-confirmation-reconciliation.md
+++ b/docs/adr/0003-payment-confirmation-reconciliation.md
@@ -1,0 +1,120 @@
+# ADR 0003: Payment confirmation, status tracking, and reconciliation
+
+- **Status:** Accepted
+- **Date:** 2026-08-22
+- **Related issue:** #314
+
+## Context
+
+Before this issue, `PaymentsService.submitSigned` treated a successful call
+to `StellarService.submitTransaction()` as equivalent to the payment being
+`CONFIRMED` — set in the same code path, with no independent verification.
+This conflates two genuinely different events: "we asked Horizon to submit
+a transaction" and "the transaction actually settled on the ledger."
+
+Classic Horizon's `POST /transactions` is synchronous — it blocks until the
+transaction closes in a ledger, so in the common case the two events are
+only milliseconds apart. But the HTTP call to Horizon can itself fail
+**ambiguously**: a client-side timeout or dropped connection can fire
+before Horizon's response arrives, even though the transaction was
+successfully included. Treating that ambiguous case as `FAILED` risks
+telling a diner their payment failed when it actually succeeded (or the
+reverse, silently doing nothing while genuinely stuck).
+
+## Decision
+
+`Payment.status` follows a guarded state machine (`payment-state-machine.ts`):
+
+```
+PENDING -> SUBMITTED -> CONFIRMED
+        \            \-> FAILED
+         \            \-> EXPIRED
+          \-> FAILED
+           \-> EXPIRED
+```
+
+**`CONFIRMED` is only ever set by `PaymentReconciliationService`, after
+independently verifying the transaction against Horizon by hash** — never
+assumed from a successful submit call, however synchronous Horizon's own
+API is.
+
+Concretely:
+
+- `PaymentsService.submitSigned` computes the transaction's hash **locally**
+  from the signed XDR (`StellarService.computeTransactionHash`) *before*
+  calling Horizon, and persists `status: SUBMITTED` with that hash
+  immediately. This is what makes the ambiguous-error case recoverable: even
+  if the submit call itself throws with no usable response, the payment
+  still carries the hash needed to look it up later.
+- A **definitive** Horizon rejection (a structured `result_codes` response,
+  or a confirmed not-found account) transitions the payment straight to
+  `FAILED` with a distinguishable `failureReason`
+  (`isDefinitiveHorizonRejection`, `horizon-error-mapper.ts`).
+- Any other (ambiguous/network/timeout) submit error leaves the payment at
+  `SUBMITTED` — it is neither assumed successful nor assumed failed.
+- `PaymentReconciliationService` polls every `SUBMITTED` payment on a short
+  interval (`@Cron(CronExpression.EVERY_10_SECONDS)`), independently
+  fetching the transaction by hash from Horizon:
+  - `successful: true` → `CONFIRMED`.
+  - `successful: false` (a rare on-ledger operation failure) → `FAILED`.
+  - "not found" (`NotFoundError`) → left `SUBMITTED`; Horizon not yet having
+    a record is expected for a few seconds after submission (propagation
+    delay), not a failure. This is the "bounded retry before falling back"
+    the issue calls for — each poll tick is one bounded attempt, bounded
+    overall by the expiry check below.
+  - any other error → left `SUBMITTED`, logged, retried next tick.
+- Once a payment's Stellar transaction timebounds
+  (`Payment.expiresAt`, mirroring `StellarService`'s own
+  `TRANSACTION_TIMEOUT_SECONDS`) pass without a confirmation ever landing,
+  the reconciliation job marks it `EXPIRED` — **not** `FAILED` — so the
+  API/UI can tell "never charged" apart from "charge attempted and
+  rejected." This applies both to `SUBMITTED` payments that never resolved
+  and to `PENDING` payments that were never even submitted.
+- `payment:status_changed` is emitted (via a new sibling `PaymentsGateway`,
+  following `OrdersGateway`'s namespace/room/auth pattern exactly) on every
+  transition — from the synchronous `submitSigned` call and from the
+  asynchronous reconciliation job alike — so the checkout UI isn't left
+  polling. A `GET /payments/stellar/:paymentId` endpoint exists alongside it
+  so a client that misses the event (e.g. reconnecting after a dropped
+  WebSocket) can fetch current status directly instead.
+
+## Alternatives considered
+
+- **Trust the synchronous submit response as confirmation**: rejected —
+  this is exactly the behavior this issue exists to fix; it can't recover
+  from an ambiguous submit-call error at all (no hash was ever recorded if
+  the call throws before a response arrives, under the old design where the
+  hash only ever came from Horizon's own response).
+- **Horizon SSE streaming as the primary confirmation mechanism**: the
+  issue suggests this for latency; not implemented here. A stream still
+  needs its own reconnect/backfill handling to be safe across a service
+  restart, and the polling job already re-checks every `SUBMITTED` payment
+  on every tick regardless of whether a stream would have caught it —
+  meaning polling alone already satisfies this issue's correctness
+  requirements (confirmation within one poll interval, i.e. a few seconds).
+  Layering a stream on top as a pure latency optimization is a reasonable,
+  clearly-scoped follow-up, not a blocking requirement.
+- **Parsing on-ledger operation-level failure reasons from `result_xdr`**:
+  the acceptance criteria only requires three distinguishable on-chain
+  failure reasons, already satisfied by the existing submit-time mapper
+  (`INSUFFICIENT_BALANCE`, `MISSING_TRUSTLINE`, `SEQUENCE_CONFLICT`). An
+  on-ledger failure caught by reconciliation (rare — most rejections happen
+  at pre-ledger validation) is recorded generically
+  (`SUBMISSION_FAILED`) rather than parsing raw `result_xdr`, which would
+  add real complexity for a case that essentially never occurs with a
+  single-operation payment transaction.
+
+## Consequences
+
+- `Payment.expiresAt` is now persisted (mirroring the transaction builder's
+  own `setTimeout`), so both the app and the reconciliation job agree on
+  when a given payment can no longer be applied.
+- `PaymentsGateway` needs `JwtService` directly, so `PaymentsModule` now
+  imports `AuthModule` itself rather than relying on `OrdersModule` to
+  re-export it (it doesn't).
+- `ScheduleModule.forRoot()` is now registered globally in `AppModule` to
+  power the reconciliation `@Cron` job.
+- The frontend work in #315 can treat `submitted` as "money may have moved,
+  wait for confirmation" and `confirmed` as the only state that's actually
+  final-success — it should never treat a successful `submit-signed` HTTP
+  response alone as proof of payment.


### PR DESCRIPTION
## Summary
- Fixes `submitSigned` conflating "Horizon accepted the submit call" with "the transaction is confirmed" — previously it set `CONFIRMED` directly on a successful submit response. It now only ever transitions `PENDING -> SUBMITTED`, storing a **locally-computed** transaction hash (`StellarService.computeTransactionHash`, derived from the signed XDR before ever calling Horizon) so an ambiguous submit error (timeout, dropped connection) leaves a recoverable trail — the payment stays `SUBMITTED` with a known hash instead of being guessed as `FAILED` or `CONFIRMED`. A *definitive* Horizon rejection (structured `result_codes`, or a confirmed not-found account — `isDefinitiveHorizonRejection`) still maps straight to `FAILED` with a distinguishable reason, unchanged from #313.
- Adds `PaymentReconciliationService`: a scheduled job (`@Cron(CronExpression.EVERY_10_SECONDS)`) that independently verifies every `SUBMITTED` payment against Horizon **by hash** — the only path in the codebase allowed to set `CONFIRMED`. A "transaction not found" response is treated as propagation delay, not failure (bounded by the expiry policy below, not by a hardcoded retry count). Reuses the existing structured error codes from #313 for the (rare) on-ledger-failure case.
- Adds an expiry policy: `Payment.expiresAt` mirrors the transaction builder's own timebounds (`StellarService.TRANSACTION_TIMEOUT_SECONDS`, now a shared constant). Once timebounds pass without ever confirming, the payment is marked `EXPIRED` — not `FAILED` — including `PENDING` payments that were never even submitted, so the API/UI can tell "never charged" apart from "charge attempted and rejected."
- Adds a guarded `payment-state-machine.ts` (`pending -> submitted -> confirmed | failed | expired`, no illegal transitions, e.g. no `confirmed -> pending`).
- Adds `PaymentsGateway`, a sibling to `OrdersGateway` following its namespace/room/auth-on-handshake pattern exactly, emitting `payment:status_changed` on every transition (from both the synchronous `submitSigned` call and the async reconciliation job).
- Adds `GET /payments/stellar/:paymentId` so a client that disconnects from the WebSocket before a confirmation event arrives can fetch current status directly on reconnect, instead of relying solely on the push event.
- Documented as `docs/adr/0003-payment-confirmation-reconciliation.md`, including the reasoning for polling-only (no SSE stream) as a correctness-sufficient, clearly-scoped choice for this issue.

## Test plan
- [x] `npm run build`
- [x] `npm run lint` (scoped to changed files — 0 errors; full-repo run shows only pre-existing CRLF-as-warning noise on untouched files, confirmed unrelated to this change)
- [x] `npm run test` — all 12 non-skipped suites / 103 tests pass, including:
  - `payment-state-machine.spec.ts` (every legal/illegal transition, exhaustively generated from the enum)
  - `payment-reconciliation.service.spec.ts` — confirms on `successful:true`, fails on `successful:false`, leaves `SUBMITTED` on "not found" (propagation delay) and on transient errors, idempotency (a confirmed payment isn't reprocessed on the next pass), expiry for both `SUBMITTED` and never-submitted `PENDING` payments, and the race where a payment confirms in the same pass its deadline passes (must not also expire it)
  - `stellar.service.spec.ts` — new `computeTransactionHash` (deterministic, no network call) and `fetchTransaction` tests
  - `payments.service.spec.ts` — updated for the new `submitSigned` behavior: marks `SUBMITTED` not `CONFIRMED`, computes the hash before calling Horizon, leaves `SUBMITTED` (doesn't throw or corrupt state) on an ambiguous network error, and the existing definitive-rejection tests (`tx_bad_seq`, underfunded) still pass unchanged

Depends on and builds directly on #312 and #313 (already merged).

Closes #314