### PR TITLE
feat(payments): wire real Stellar wallet checkout UX for diners

### DIFF
--- a/backend/src/modules/orders/diner-orders.controller.spec.ts
+++ b/backend/src/modules/orders/diner-orders.controller.spec.ts
@@ -1,0 +1,70 @@
+import { DinerOrdersController } from './diner-orders.controller';
+import { MalformedPaymentRequestError } from '../payments/errors/payment.errors';
+import type { CheckoutRequest } from './guards/diner-checkout.guard';
+
+function makeRequest(orderId: string, restaurantId: string): CheckoutRequest {
+  return { checkoutContext: { orderId, restaurantId } } as CheckoutRequest;
+}
+
+describe('DinerOrdersController', () => {
+  let ordersService: { findOne: jest.Mock };
+  let controller: DinerOrdersController;
+
+  beforeEach(() => {
+    ordersService = { findOne: jest.fn() };
+    controller = new DinerOrdersController(ordersService as any);
+  });
+
+  it('rejects a path orderId that does not match the checkout token', async () => {
+    const req = makeRequest('order-1', 'restaurant-1');
+
+    await expect(
+      controller.getCheckoutSummary(req, 'a-different-order'),
+    ).rejects.toThrow(MalformedPaymentRequestError);
+    expect(ordersService.findOne).not.toHaveBeenCalled();
+  });
+
+  it('returns a diner-safe summary scoped to the checkout token', async () => {
+    const req = makeRequest('order-1', 'restaurant-1');
+    ordersService.findOne.mockResolvedValueOnce({
+      id: 'order-1',
+      orderNumber: 'ORD-1',
+      items: [{ name: 'Jollof Rice', quantity: 2, price: 12 }],
+      total: 24,
+      currency: 'XLM',
+      status: 'pending',
+    });
+
+    const result = await controller.getCheckoutSummary(req, 'order-1');
+
+    expect(ordersService.findOne).toHaveBeenCalledWith(
+      'order-1',
+      'restaurant-1',
+    );
+    expect(result).toEqual({
+      orderId: 'order-1',
+      orderNumber: 'ORD-1',
+      items: [{ name: 'Jollof Rice', quantity: 2, price: 12 }],
+      total: 24,
+      currency: 'XLM',
+      status: 'pending',
+    });
+  });
+
+  it('coerces a decimal total returned as a string (TypeORM decimal columns) to a number', async () => {
+    const req = makeRequest('order-1', 'restaurant-1');
+    ordersService.findOne.mockResolvedValueOnce({
+      id: 'order-1',
+      orderNumber: 'ORD-1',
+      items: [],
+      total: '24.00',
+      currency: 'XLM',
+      status: 'pending',
+    });
+
+    const result = await controller.getCheckoutSummary(req, 'order-1');
+
+    expect(result.total).toBe(24);
+    expect(typeof result.total).toBe('number');
+  });
+});

--- a/backend/src/modules/orders/diner-orders.controller.ts
+++ b/backend/src/modules/orders/diner-orders.controller.ts
@@ -1,0 +1,50 @@
+// backend/src/modules/orders/diner-orders.controller.ts
+import { Controller, Get, Param, Request, UseGuards } from '@nestjs/common';
+import { Public } from '../../common/decorators/public.decorator';
+import { MalformedPaymentRequestError } from '../payments/errors/payment.errors';
+import {
+  CheckoutRequest,
+  DinerCheckoutGuard,
+} from './guards/diner-checkout.guard';
+import { OrdersService } from './orders.service';
+
+// Diner-facing counterpart to OrdersController, which is entirely
+// staff-gated (class-level JwtAuthGuard). A diner arriving via a scanned
+// QR code (ADR 0002) has a checkout token, not a staff session, and needs
+// enough of their own order — items and total — to render the checkout UI
+// (issue #315) without the frontend inventing or mocking that data.
+@Controller('orders')
+@Public()
+@UseGuards(DinerCheckoutGuard)
+export class DinerOrdersController {
+  constructor(private readonly ordersService: OrdersService) {}
+
+  @Get(':orderId/checkout-summary')
+  async getCheckoutSummary(
+    @Request() req: CheckoutRequest,
+    @Param('orderId') orderId: string,
+  ) {
+    if (req.checkoutContext.orderId !== orderId) {
+      throw new MalformedPaymentRequestError({
+        reason: 'orderId does not match checkout token',
+      });
+    }
+
+    const order = await this.ordersService.findOne(
+      orderId,
+      req.checkoutContext.restaurantId,
+    );
+
+    return {
+      orderId: order.id,
+      orderNumber: order.orderNumber,
+      items: order.items,
+      // TypeORM returns `decimal` columns as strings to avoid precision
+      // loss — OrdersController.create() already does this same coercion
+      // when returning `total` to a client.
+      total: Number(order.total),
+      currency: order.currency,
+      status: order.status,
+    };
+  }
+}

--- a/backend/src/modules/orders/orders.module.ts
+++ b/backend/src/modules/orders/orders.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
 import { Order } from './order.entity';
+import { DinerOrdersController } from './diner-orders.controller';
 import { OrdersController } from './orders.controller';
 import { OrdersGateway } from './orders.gateway';
 import { OrdersService } from './orders.service';
@@ -11,7 +12,7 @@ import { DinerCheckoutGuard } from './guards/diner-checkout.guard';
 
 @Module({
   imports: [AuthModule, TypeOrmModule.forFeature([Order])],
-  controllers: [OrdersController],
+  controllers: [OrdersController, DinerOrdersController],
   providers: [
     OrdersGateway,
     OrdersService,

--- a/backend/src/modules/payments/dto/build-trustline.dto.ts
+++ b/backend/src/modules/payments/dto/build-trustline.dto.ts
@@ -1,0 +1,21 @@
+// backend/src/modules/payments/dto/build-trustline.dto.ts
+import { IsIn, IsString, Length } from 'class-validator';
+
+export class BuildTrustlineDto {
+  // The diner's own wallet — same non-custodial constraint as
+  // InitiatePaymentDto.sourceAccount (ADR 0001).
+  @IsString()
+  @Length(56, 56)
+  sourceAccount: string;
+
+  // Only USDC needs a trustline today (XLM is native); kept as an allowlist
+  // rather than a free string so this can't be used to build a changeTrust
+  // transaction for an arbitrary/unvetted asset.
+  @IsString()
+  @IsIn(['USDC'])
+  assetCode: string;
+
+  @IsString()
+  @Length(56, 56)
+  assetIssuer: string;
+}

--- a/backend/src/modules/payments/payments.controller.spec.ts
+++ b/backend/src/modules/payments/payments.controller.spec.ts
@@ -1,0 +1,130 @@
+import { Keypair } from '@stellar/stellar-sdk';
+import { PaymentsController } from './payments.controller';
+import { MalformedPaymentRequestError } from './errors/payment.errors';
+
+// A real, validly-checksummed key — hand-typed StrKey addresses are easy to
+// get subtly wrong (invalid checksum), which would make "valid key" tests
+// accidentally exercise the "invalid key" path instead.
+const validKey = Keypair.random().publicKey();
+
+describe('PaymentsController', () => {
+  let paymentsService: {
+    initiate: jest.Mock;
+    submitSigned: jest.Mock;
+    findOne: jest.Mock;
+  };
+  let stellarService: {
+    getAccountTrustlines: jest.Mock;
+    buildTrustlineTransaction: jest.Mock;
+    submitTransaction: jest.Mock;
+  };
+  let controller: PaymentsController;
+
+  beforeEach(() => {
+    paymentsService = {
+      initiate: jest.fn(),
+      submitSigned: jest.fn(),
+      findOne: jest.fn(),
+    };
+    stellarService = {
+      getAccountTrustlines: jest.fn(),
+      buildTrustlineTransaction: jest.fn(),
+      submitTransaction: jest.fn(),
+    };
+    controller = new PaymentsController(
+      paymentsService as any,
+      stellarService as any,
+    );
+  });
+
+  describe('getTrustlines', () => {
+    it('rejects a malformed public key without calling StellarService', async () => {
+      await expect(controller.getTrustlines('not-a-key')).rejects.toThrow(
+        MalformedPaymentRequestError,
+      );
+      expect(stellarService.getAccountTrustlines).not.toHaveBeenCalled();
+    });
+
+    it('delegates a valid public key to StellarService', async () => {
+      stellarService.getAccountTrustlines.mockResolvedValueOnce({
+        funded: true,
+        balances: [],
+      });
+
+      const result = await controller.getTrustlines(validKey);
+
+      expect(stellarService.getAccountTrustlines).toHaveBeenCalledWith(
+        validKey,
+      );
+      expect(result).toEqual({ funded: true, balances: [] });
+    });
+  });
+
+  describe('buildTrustline', () => {
+    const issuer = Keypair.random().publicKey();
+
+    it('rejects a malformed sourceAccount without calling StellarService', async () => {
+      await expect(
+        controller.buildTrustline({
+          sourceAccount: 'not-a-key',
+          assetCode: 'USDC',
+          assetIssuer: issuer,
+        } as any),
+      ).rejects.toThrow(MalformedPaymentRequestError);
+      expect(stellarService.buildTrustlineTransaction).not.toHaveBeenCalled();
+    });
+
+    it('rejects a malformed assetIssuer without calling StellarService', async () => {
+      await expect(
+        controller.buildTrustline({
+          sourceAccount: validKey,
+          assetCode: 'USDC',
+          assetIssuer: 'not-a-key',
+        } as any),
+      ).rejects.toThrow(MalformedPaymentRequestError);
+      expect(stellarService.buildTrustlineTransaction).not.toHaveBeenCalled();
+    });
+
+    it('builds and returns the unsigned XDR for valid input', async () => {
+      stellarService.buildTrustlineTransaction.mockResolvedValueOnce(
+        'fake-xdr',
+      );
+
+      const result = await controller.buildTrustline({
+        sourceAccount: validKey,
+        assetCode: 'USDC',
+        assetIssuer: issuer,
+      } as any);
+
+      expect(result).toEqual({ unsignedTransactionXdr: 'fake-xdr' });
+    });
+  });
+
+  describe('submitTrustline', () => {
+    it('submits via StellarService and returns the outcome', async () => {
+      stellarService.submitTransaction.mockResolvedValueOnce({
+        successful: true,
+        hash: 'fake-hash',
+      });
+
+      const result = await controller.submitTrustline({
+        signedTransactionXdr: 'signed-xdr',
+      });
+
+      expect(stellarService.submitTransaction).toHaveBeenCalledWith(
+        'signed-xdr',
+      );
+      expect(result).toEqual({ successful: true, hash: 'fake-hash' });
+    });
+
+    it('maps a Horizon rejection to a structured PaymentError', async () => {
+      stellarService.submitTransaction.mockRejectedValueOnce(
+        new Error('unexpected horizon failure'),
+      );
+
+      await expect(
+        controller.submitTrustline({ signedTransactionXdr: 'signed-xdr' }),
+      ).rejects.toMatchObject({ code: 'SUBMISSION_FAILED' });
+    });
+  });
+});

--- a/backend/src/modules/payments/payments.controller.ts
+++ b/backend/src/modules/payments/payments.controller.ts
@@ -9,15 +9,19 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
+import { StrKey } from '@stellar/stellar-sdk';
 import { Public } from '../../common/decorators/public.decorator';
 import {
   DinerCheckoutGuard,
   CheckoutRequest,
 } from '../orders/guards/diner-checkout.guard';
+import { BuildTrustlineDto } from './dto/build-trustline.dto';
 import { InitiatePaymentDto } from './dto/initiate-payment.dto';
 import { SubmitSignedPaymentDto } from './dto/submit-signed-payment.dto';
 import { PaymentsService } from './payments.service';
+import { StellarService } from './stellar.service';
 import { MalformedPaymentRequestError } from './errors/payment.errors';
+import { mapHorizonSubmissionError } from './errors/horizon-error-mapper';
 
 // Diner-facing, not staff-facing (see ADR 0002) — @Public() bypasses the
 // global staff JwtAuthGuard, and DinerCheckoutGuard is the real gate here.
@@ -25,7 +29,10 @@ import { MalformedPaymentRequestError } from './errors/payment.errors';
 @Public()
 @UseGuards(DinerCheckoutGuard)
 export class PaymentsController {
-  constructor(private readonly paymentsService: PaymentsService) {}
+  constructor(
+    private readonly paymentsService: PaymentsService,
+    private readonly stellarService: StellarService,
+  ) {}
 
   // Throttled tighter than the app default — a diner initiates a payment
   // once per checkout, not in a tight loop; this bounds abuse of an
@@ -64,6 +71,53 @@ export class PaymentsController {
     @Param('paymentId') paymentId: string,
   ) {
     return this.paymentsService.findOne(paymentId, req.checkoutContext.orderId);
+  }
+
+  // Lets the checkout UI decide, before building a payment, whether the
+  // diner's connected wallet needs a trustline-setup step first (issue
+  // #315) instead of letting a non-native payment fail opaquely on
+  // `op_no_trust`.
+  @Get('account/:publicKey/trustlines')
+  async getTrustlines(@Param('publicKey') publicKey: string) {
+    this.assertValidPublicKey(publicKey);
+    return this.stellarService.getAccountTrustlines(publicKey);
+  }
+
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
+  @Post('account/trustline')
+  async buildTrustline(@Body() dto: BuildTrustlineDto) {
+    this.assertValidPublicKey(dto.sourceAccount);
+    this.assertValidPublicKey(dto.assetIssuer);
+    const unsignedTransactionXdr =
+      await this.stellarService.buildTrustlineTransaction(dto);
+    return { unsignedTransactionXdr };
+  }
+
+  // Trustline setup isn't a Payment (no restaurant destination, no
+  // idempotency key, no PaymentStatus lifecycle) — the Payment entity
+  // models a specific settlement to a specific restaurant, not every
+  // transaction a diner's wallet might submit. Submitting it here, straight
+  // through StellarService, keeps that model from being stretched to cover
+  // a step that isn't actually a payment.
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
+  @Post('account/trustline/submit')
+  async submitTrustline(@Body() dto: SubmitSignedPaymentDto) {
+    try {
+      const result = await this.stellarService.submitTransaction(
+        dto.signedTransactionXdr,
+      );
+      return { successful: result.successful, hash: result.hash };
+    } catch (error) {
+      throw mapHorizonSubmissionError(error);
+    }
+  }
+
+  private assertValidPublicKey(publicKey: string): void {
+    if (!StrKey.isValidEd25519PublicKey(publicKey)) {
+      throw new MalformedPaymentRequestError({
+        reason: 'not a valid Stellar public key',
+      });
+    }
   }
 
   // A valid checkout token only ever authorizes the order it was issued

--- a/backend/src/modules/payments/stellar.service.spec.ts
+++ b/backend/src/modules/payments/stellar.service.spec.ts
@@ -1,4 +1,4 @@
-import { Account, Keypair, Networks } from '@stellar/stellar-sdk';
+import { Account, Keypair, Networks, NotFoundError } from '@stellar/stellar-sdk';
 import { StellarService } from './stellar.service';
 
 // Real, validly-checksummed keys generated at test time — hand-typed
@@ -231,6 +231,78 @@ describe('StellarService', () => {
       await expect(service.fetchTransaction('missing-hash')).rejects.toThrow(
         'not found',
       );
+    });
+  });
+
+  describe('getAccountTrustlines', () => {
+    it('reports funded:false for an account that does not exist on the network', async () => {
+      const service = readyService();
+      mockLoadAccount.mockRejectedValueOnce(new NotFoundError('not found', {}));
+
+      const result = await service.getAccountTrustlines(
+        sourceKeypair.publicKey(),
+      );
+
+      expect(result).toEqual({ funded: false, balances: [] });
+    });
+
+    it('propagates a non-NotFoundError failure instead of swallowing it', async () => {
+      const service = readyService();
+      const outage = new Error('horizon unreachable');
+      mockLoadAccount.mockRejectedValueOnce(outage);
+
+      await expect(
+        service.getAccountTrustlines(sourceKeypair.publicKey()),
+      ).rejects.toThrow('horizon unreachable');
+    });
+
+    it('maps native and non-native balances to a flat, typed list', async () => {
+      const service = readyService();
+      const issuer = Keypair.random().publicKey();
+      mockLoadAccount.mockResolvedValueOnce({
+        balances: [
+          { asset_type: 'native', balance: '42.0000000' },
+          {
+            asset_type: 'credit_alphanum4',
+            asset_code: 'USDC',
+            asset_issuer: issuer,
+            balance: '10.0000000',
+          },
+        ],
+      });
+
+      const result = await service.getAccountTrustlines(
+        sourceKeypair.publicKey(),
+      );
+
+      expect(result).toEqual({
+        funded: true,
+        balances: [
+          { assetCode: 'XLM', assetIssuer: null, balance: '42.0000000' },
+          { assetCode: 'USDC', assetIssuer: issuer, balance: '10.0000000' },
+        ],
+      });
+    });
+  });
+
+  describe('buildTrustlineTransaction', () => {
+    it('builds a signable changeTrust XDR envelope', async () => {
+      const service = readyService();
+      mockLoadAccount.mockResolvedValueOnce(
+        new Account(sourceKeypair.publicKey(), '100'),
+      );
+      mockFetchBaseFee.mockResolvedValueOnce(100);
+
+      const issuer = Keypair.random().publicKey();
+      const xdr = await service.buildTrustlineTransaction({
+        sourceAccount: sourceKeypair.publicKey(),
+        assetCode: 'USDC',
+        assetIssuer: issuer,
+      });
+
+      expect(typeof xdr).toBe('string');
+      expect(xdr.length).toBeGreaterThan(0);
+      expect(mockLoadAccount).toHaveBeenCalledWith(sourceKeypair.publicKey());
     });
   });
 });

--- a/backend/src/modules/payments/stellar.service.ts
+++ b/backend/src/modules/payments/stellar.service.ts
@@ -7,6 +7,7 @@ import {
   Horizon,
   Memo,
   Networks,
+  NotFoundError,
   Operation,
   TransactionBuilder,
 } from '@stellar/stellar-sdk';
@@ -30,6 +31,30 @@ export interface BuildPaymentTransactionParams {
    * compensates by constructing the Account one below this value.
    */
   sequenceOverride?: string;
+}
+
+export interface BuildTrustlineTransactionParams {
+  sourceAccount: string;
+  assetCode: string;
+  assetIssuer: string;
+}
+
+export interface TrustlineBalance {
+  /** 'XLM' for the native balance, otherwise the asset code (e.g. 'USDC'). */
+  assetCode: string;
+  /** null for the native balance — Asset.native() has no issuer. */
+  assetIssuer: string | null;
+  balance: string;
+}
+
+export interface AccountTrustlines {
+  /**
+   * false when the account doesn't exist on the network yet (issue #315
+   * edge case: a brand-new address with zero XLM can't hold a trustline —
+   * or anything — until it's funded with the minimum reserve).
+   */
+  funded: boolean;
+  balances: TrustlineBalance[];
 }
 
 // Shared between the transaction builder's own timeout and the Payment's
@@ -170,5 +195,61 @@ export class StellarService implements OnModuleInit {
     hash: string,
   ): Promise<Horizon.ServerApi.TransactionRecord> {
     return this.server.transactions().transaction(hash).call();
+  }
+
+  /**
+   * Reports which assets `publicKey` already trusts, so #315's checkout UI
+   * can offer a trustline-setup step before a payment attempt fails with
+   * `op_no_trust` (see errors/horizon-error-mapper.ts). A NotFoundError here
+   * means the account has never been created/funded on this network at
+   * all — distinct from "funded but missing this one trustline" — so
+   * callers can show the right guidance for each case.
+   */
+  async getAccountTrustlines(publicKey: string): Promise<AccountTrustlines> {
+    try {
+      const account = await this.server.loadAccount(publicKey);
+      const balances: TrustlineBalance[] = account.balances.map((entry) => {
+        if (entry.asset_type === 'native') {
+          return { assetCode: 'XLM', assetIssuer: null, balance: entry.balance };
+        }
+        const trustline = entry as Horizon.HorizonApi.BalanceLineAsset;
+        return {
+          assetCode: trustline.asset_code,
+          assetIssuer: trustline.asset_issuer,
+          balance: trustline.balance,
+        };
+      });
+      return { funded: true, balances };
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        return { funded: false, balances: [] };
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Builds an unsigned `changeTrust` transaction so a diner's wallet can
+   * establish a trustline before paying in a non-native asset (issue #315).
+   * Always loads the account fresh (no sequence override): unlike payments,
+   * trustline setup isn't behind SequenceAllocator — it's a one-off step the
+   * diner takes sequentially, not a contended, idempotency-tracked resource.
+   */
+  async buildTrustlineTransaction(
+    params: BuildTrustlineTransactionParams,
+  ): Promise<string> {
+    const sourceAccount = await this.server.loadAccount(params.sourceAccount);
+    const baseFee = await this.server.fetchBaseFee();
+    const asset = new Asset(params.assetCode, params.assetIssuer);
+
+    const transaction = new TransactionBuilder(sourceAccount, {
+      fee: String(baseFee),
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(Operation.changeTrust({ asset }))
+      .setTimeout(TRANSACTION_TIMEOUT_SECONDS)
+      .build();
+
+    return transaction.toXDR();
   }
 }

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,18 @@
+# Backend API base URL (must include the /api prefix backend/src/main.ts sets)
+NEXT_PUBLIC_API_URL=http://localhost:3001
+
+# Socket.IO base URL. Defaults to NEXT_PUBLIC_API_URL with a trailing /api
+# stripped, since Socket.IO namespaces (e.g. /orders) live on the bare host.
+NEXT_PUBLIC_SOCKET_URL=http://localhost:3001
+
+# Diner checkout (issue #315) — must match the backend's STELLAR_NETWORK
+# (see backend/.env.example) so wallet signature requests and the Stellar
+# Explorer link both target the right network.
+NEXT_PUBLIC_STELLAR_NETWORK=testnet
+
+# USDC issuer account for this network. There is no single well-known USDC
+# issuer across every Stellar network/environment (testnet issuers in
+# particular are not standardized) — set this explicitly rather than
+# guessing. Leaving it unset disables USDC checkout; XLM checkout still
+# works, since XLM is the native asset and needs no issuer or trustline.
+NEXT_PUBLIC_USDC_ASSET_ISSUER=

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/frontend/app/checkout/[orderId]/page.tsx
+++ b/frontend/app/checkout/[orderId]/page.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+import { useParams, useSearchParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import StellarCheckout, {
+  type CartItem,
+  type SettlementAsset,
+} from "@/components/checkout/StellarCheckout";
+import { CheckoutApiError, fetchCheckoutSummary } from "@/lib/api/checkoutClient";
+
+const PAYABLE_ASSETS: readonly SettlementAsset[] = ["XLM", "USDC"];
+
+function isPayableAsset(value: string): value is SettlementAsset {
+  return (PAYABLE_ASSETS as readonly string[]).includes(value);
+}
+
+/**
+ * Diner-facing checkout page — the route the QR code printed at a table
+ * actually points to (issue #315: the checkout component wasn't reachable
+ * from any route before this). The order and its checkout token both come
+ * from the URL: `orderId` from the path, the short-lived checkout token
+ * (ADR 0002) from `?token=`, exactly as the staff-issued QR code encodes it.
+ */
+export default function CheckoutPage() {
+  const { orderId } = useParams<{ orderId: string }>();
+  const checkoutToken = useSearchParams().get("token");
+  const [cancelled, setCancelled] = useState(false);
+
+  const summaryQuery = useQuery({
+    queryKey: ["checkout-summary", orderId, checkoutToken],
+    queryFn: () => fetchCheckoutSummary(checkoutToken as string, orderId),
+    enabled: Boolean(orderId) && Boolean(checkoutToken),
+    retry: false,
+  });
+
+  if (!checkoutToken) {
+    return (
+      <CheckoutMessage
+        title="Missing checkout link"
+        body="This link is missing its checkout token. Please rescan the table QR code."
+      />
+    );
+  }
+
+  if (cancelled) {
+    return (
+      <CheckoutMessage
+        title="Checkout cancelled"
+        body="You can rescan the table QR code to start again whenever you're ready."
+      />
+    );
+  }
+
+  if (summaryQuery.isLoading) {
+    return (
+      <div className="mx-auto max-w-md p-6">
+        <p className="text-sm text-gray-500">Loading your order…</p>
+      </div>
+    );
+  }
+
+  if (summaryQuery.isError) {
+    const message =
+      summaryQuery.error instanceof CheckoutApiError
+        ? summaryQuery.error.message
+        : "Couldn't load this order.";
+    return (
+      <CheckoutMessage
+        title="Couldn't load your order"
+        body={`${message} If this checkout link is more than a few minutes old, rescan the table QR code for a fresh one.`}
+      />
+    );
+  }
+
+  const summary = summaryQuery.data;
+  if (!summary) {
+    return (
+      <CheckoutMessage
+        title="Couldn't load your order"
+        body="No order data came back. Please rescan the table QR code."
+      />
+    );
+  }
+  if (!isPayableAsset(summary.currency)) {
+    return (
+      <CheckoutMessage
+        title="This order can't be paid here yet"
+        body={`This order is set up to settle in "${summary.currency}", which isn't supported by this checkout flow.`}
+      />
+    );
+  }
+
+  const items: CartItem[] = summary.items.map((item, index) => ({
+    id: `${summary.orderId}-${index}`,
+    name: item.name,
+    price: item.price,
+    quantity: item.quantity,
+  }));
+
+  return (
+    <div className="mx-auto max-w-md p-6">
+      <StellarCheckout
+        orderId={summary.orderId}
+        checkoutToken={checkoutToken}
+        items={items}
+        total={summary.total}
+        asset={summary.currency}
+        onCancel={() => setCancelled(true)}
+      />
+    </div>
+  );
+}
+
+function CheckoutMessage({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="mx-auto max-w-md p-6">
+      <div className="rounded-2xl border border-gray-200 bg-white p-6 text-center shadow-sm">
+        <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+        <p className="mt-2 text-sm text-gray-600">{body}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/checkout/StellarCheckout.tsx
+++ b/frontend/components/checkout/StellarCheckout.tsx
@@ -1,8 +1,24 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
+import {
+  buildTrustlineTransaction,
+  CheckoutApiError,
+  fetchPaymentStatus,
+  fetchTrustlines,
+  initiatePayment,
+  submitSignedPayment,
+  submitTrustlineTransaction,
+} from "@/lib/api/checkoutClient";
+import {
+  connectWallet,
+  disconnectWallet,
+  signTransactionXdr,
+  WalletError,
+} from "@/lib/stellar/wallet";
+import type { PaymentErrorCode, PaymentStatus } from "@/lib/types/payments";
 
-export type StellarAsset = "XLM" | "USDC" | "BITE";
+export type SettlementAsset = "XLM" | "USDC";
 
 export interface CartItem {
   id: string;
@@ -12,72 +28,320 @@ export interface CartItem {
 }
 
 interface StellarCheckoutProps {
+  orderId: string;
+  // Short-lived, order-scoped token from the QR-encoded checkout URL
+  // (ADR 0002) — this, not a staff session, is what authorizes these calls.
+  checkoutToken: string;
   items: CartItem[];
-  onSuccess?: (txHash: string) => void;
+  // The order's total and settlement asset are decided when the order is
+  // created (see backend/src/modules/orders/order.entity.ts) — not a free
+  // choice made here. Offering an asset dropdown, as the old mock did,
+  // would let a diner "pay" in an asset the order was never priced in.
+  total: number;
+  asset: SettlementAsset;
+  onSuccess?: (result: { paymentId: string; stellarTxHash: string }) => void;
   onCancel?: () => void;
 }
 
-const ASSET_DECIMALS: Record<StellarAsset, number> = {
-  XLM: 7,
-  USDC: 7,
-  BITE: 7,
-};
+type Phase =
+  | "connect"
+  | "checking-trustline"
+  | "needs-trustline"
+  | "setting-up-trustline"
+  | "ready"
+  | "paying"
+  | "confirming"
+  | "success"
+  | "error";
 
-function formatAssetAmount(amount: number, asset: StellarAsset): string {
-  return amount.toFixed(ASSET_DECIMALS[asset]);
+interface CheckoutError {
+  message: string;
+  retryable: boolean;
 }
 
-function calcTotal(items: CartItem[]): number {
-  return items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+// Kept out of the backend's asset allowlist (only USDC needs a trustline —
+// see backend dto/build-trustline.dto.ts) and undocumented on the network
+// side, so unlike XLM/USDC an issuer address can't be safely hardcoded here.
+// Without it configured, USDC checkout is disabled rather than guessed at.
+const USDC_ASSET_ISSUER = process.env.NEXT_PUBLIC_USDC_ASSET_ISSUER;
+
+// Mirrors StellarService.TRANSACTION_TIMEOUT_SECONDS — once a submitted
+// transaction's timebounds pass without independent confirmation, the
+// backend's reconciliation job marks it EXPIRED; polling past that point
+// would just wait for a status that's already decided.
+const STATUS_POLL_INTERVAL_MS = 3000;
+const STATUS_POLL_TIMEOUT_MS = 180_000;
+
+const STELLAR_EXPERT_NETWORK_SEGMENT =
+  (process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? "testnet").toLowerCase() ===
+  "public"
+    ? "public"
+    : "testnet";
+
+function formatAssetAmount(amount: number): string {
+  return amount.toFixed(7);
+}
+
+function describeError(error: unknown): CheckoutError {
+  if (error instanceof WalletError) {
+    if (error.kind === "wallet_rejected") {
+      return {
+        message: "You declined the request in your wallet.",
+        retryable: true,
+      };
+    }
+    return { message: `Wallet error: ${error.message}`, retryable: true };
+  }
+
+  if (error instanceof CheckoutApiError) {
+    return {
+      message: describePaymentErrorCode(
+        error.code as PaymentErrorCode | undefined,
+        error.message
+      ),
+      retryable: error.code !== "RESTAURANT_WALLET_NOT_CONFIGURED",
+    };
+  }
+
+  return {
+    message: error instanceof Error ? error.message : "Something went wrong.",
+    retryable: true,
+  };
+}
+
+function describePaymentErrorCode(
+  code: PaymentErrorCode | undefined,
+  fallback: string
+): string {
+  switch (code) {
+    case "INSUFFICIENT_BALANCE":
+      return "Your wallet doesn't have enough balance to cover this payment.";
+    case "MISSING_TRUSTLINE":
+      return "Your wallet is missing a trustline for this asset.";
+    case "SEQUENCE_CONFLICT":
+      return "This payment attempt expired — please try again.";
+    case "RESTAURANT_WALLET_NOT_CONFIGURED":
+      return "This restaurant hasn't set up a payout wallet yet. Please tell staff.";
+    case "IDEMPOTENCY_CONFLICT":
+      return "This checkout session is out of sync — please refresh and try again.";
+    case "MALFORMED_REQUEST":
+      return "This payment request was invalid. Please refresh and try again.";
+    default:
+      return fallback || "The network rejected this payment.";
+  }
+}
+
+function describeTerminalStatus(
+  status: PaymentStatus,
+  failureReason: PaymentErrorCode | null
+): CheckoutError {
+  if (status === "expired") {
+    return {
+      message:
+        "This payment expired before it could be confirmed. Please try again.",
+      retryable: true,
+    };
+  }
+  return {
+    message: describePaymentErrorCode(failureReason ?? undefined, "This payment failed."),
+    retryable: true,
+  };
 }
 
 export default function StellarCheckout({
+  orderId,
+  checkoutToken,
   items,
+  total,
+  asset,
   onSuccess,
   onCancel,
 }: StellarCheckoutProps) {
-  const [asset, setAsset] = useState<StellarAsset>("XLM");
-  const [walletAddress, setWalletAddress] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [step, setStep] = useState<"review" | "confirm" | "done">("review");
+  const [phase, setPhase] = useState<Phase>("connect");
+  const [walletAddress, setWalletAddress] = useState<string | null>(null);
+  const [error, setError] = useState<CheckoutError | null>(null);
   const [txHash, setTxHash] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
 
-  const total = calcTotal(items);
+  const idempotencyKeyRef = useRef<string | null>(null);
+  const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  async function handleConfirm() {
-    setError(null);
+  useEffect(() => {
+    return () => {
+      if (pollTimerRef.current) clearInterval(pollTimerRef.current);
+      void disconnectWallet();
+    };
+  }, []);
 
-    if (!walletAddress.trim()) {
-      setError("Please enter your Stellar wallet address.");
-      return;
-    }
-
-    if (!/^G[A-Z2-7]{55}$/.test(walletAddress.trim())) {
-      setError("Invalid Stellar address. Must start with G and be 56 chars.");
-      return;
-    }
-
-    setLoading(true);
-    try {
-      // In production this calls your backend /payments/stellar/initiate
-      // which builds and submits the transaction via Horizon.
-      await new Promise((res) => setTimeout(res, 1200));
-      const mockHash =
-        "TX" + Math.random().toString(36).substring(2, 18).toUpperCase();
-      setTxHash(mockHash);
-      setStep("done");
-      onSuccess?.(mockHash);
-    } catch (err: unknown) {
-      setError(
-        err instanceof Error ? err.message : "Payment failed. Please retry."
-      );
-    } finally {
-      setLoading(false);
+  function stopPolling(): void {
+    if (pollTimerRef.current) {
+      clearInterval(pollTimerRef.current);
+      pollTimerRef.current = null;
     }
   }
 
-  if (step === "done" && txHash) {
+  async function checkTrustline(address: string): Promise<void> {
+    if (!USDC_ASSET_ISSUER) {
+      setError({
+        message: "USDC payments aren't configured for this restaurant yet.",
+        retryable: false,
+      });
+      setPhase("error");
+      return;
+    }
+    try {
+      const trustlines = await fetchTrustlines(checkoutToken, address);
+      if (!trustlines.funded) {
+        setError({
+          message:
+            "This wallet has no funded Stellar account yet. Fund it with a small amount of XLM, then reconnect.",
+          retryable: false,
+        });
+        setPhase("error");
+        return;
+      }
+      const hasTrustline = trustlines.balances.some(
+        (b) => b.assetCode === "USDC" && b.assetIssuer === USDC_ASSET_ISSUER
+      );
+      setPhase(hasTrustline ? "ready" : "needs-trustline");
+    } catch (err) {
+      setError(describeError(err));
+      setPhase("error");
+    }
+  }
+
+  async function handleConnect(): Promise<void> {
+    setError(null);
+    setBusy(true);
+    try {
+      const { address } = await connectWallet();
+      setWalletAddress(address);
+      // A new wallet is a new payment attempt — the old idempotency key (if
+      // any) belonged to a payment sourced from a different account.
+      idempotencyKeyRef.current = null;
+      if (asset === "USDC") {
+        setPhase("checking-trustline");
+        await checkTrustline(address);
+      } else {
+        setPhase("ready");
+      }
+    } catch (err) {
+      setError(describeError(err));
+      setPhase("error");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleSetupTrustline(): Promise<void> {
+    if (!walletAddress || !USDC_ASSET_ISSUER) return;
+    setError(null);
+    setBusy(true);
+    setPhase("setting-up-trustline");
+    try {
+      const built = await buildTrustlineTransaction(checkoutToken, {
+        sourceAccount: walletAddress,
+        assetCode: "USDC",
+        assetIssuer: USDC_ASSET_ISSUER,
+      });
+      const signed = await signTransactionXdr(
+        built.unsignedTransactionXdr,
+        walletAddress
+      );
+      await submitTrustlineTransaction(checkoutToken, signed);
+      setPhase("ready");
+    } catch (err) {
+      setError(describeError(err));
+      setPhase("needs-trustline");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function startPolling(paymentId: string): void {
+    const startedAt = Date.now();
+    pollTimerRef.current = setInterval(() => {
+      void (async () => {
+        if (Date.now() - startedAt > STATUS_POLL_TIMEOUT_MS) {
+          stopPolling();
+          setError({
+            message:
+              "We couldn't confirm this payment in time. Check your wallet — it may still complete on-chain.",
+            retryable: false,
+          });
+          setPhase("error");
+          return;
+        }
+        try {
+          const record = await fetchPaymentStatus(checkoutToken, paymentId);
+          if (record.status === "confirmed") {
+            stopPolling();
+            setTxHash(record.stellarTxHash);
+            setPhase("success");
+            if (record.stellarTxHash) {
+              onSuccess?.({ paymentId, stellarTxHash: record.stellarTxHash });
+            }
+          } else if (record.status === "failed" || record.status === "expired") {
+            stopPolling();
+            setError(describeTerminalStatus(record.status, record.failureReason));
+            setPhase("error");
+          }
+          // pending/submitted: still confirming, keep polling.
+        } catch {
+          // A transient poll failure isn't fatal on its own — retry until
+          // STATUS_POLL_TIMEOUT_MS gives up for good.
+        }
+      })();
+    }, STATUS_POLL_INTERVAL_MS);
+  }
+
+  async function handlePay(): Promise<void> {
+    if (!walletAddress) return;
+    setError(null);
+    setBusy(true);
+    setPhase("paying");
+    if (!idempotencyKeyRef.current) {
+      idempotencyKeyRef.current = crypto.randomUUID();
+    }
+    try {
+      const initiated = await initiatePayment(checkoutToken, {
+        orderId,
+        sourceAccount: walletAddress,
+        assetCode: asset,
+        assetIssuer: asset === "USDC" ? USDC_ASSET_ISSUER : undefined,
+        amount: formatAssetAmount(total),
+        idempotencyKey: idempotencyKeyRef.current,
+      });
+
+      const signed = await signTransactionXdr(
+        initiated.unsignedTransactionXdr,
+        walletAddress
+      );
+
+      await submitSignedPayment(checkoutToken, initiated.paymentId, signed);
+      setPhase("confirming");
+      startPolling(initiated.paymentId);
+    } catch (err) {
+      setError(describeError(err));
+      setPhase("ready");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function handleRetry(): void {
+    setError(null);
+    if (!walletAddress) {
+      setPhase("connect");
+    } else if (asset === "USDC") {
+      setPhase("checking-trustline");
+      void checkTrustline(walletAddress);
+    } else {
+      setPhase("ready");
+    }
+  }
+
+  if (phase === "success" && txHash) {
     return (
       <div className="flex flex-col items-center gap-4 rounded-2xl border border-green-200 bg-green-50 p-8">
         <div className="text-4xl">✅</div>
@@ -85,13 +349,13 @@ export default function StellarCheckout({
           Payment Successful
         </h2>
         <p className="text-sm text-green-700">
-          {formatAssetAmount(total, asset)} {asset} sent
+          {formatAssetAmount(total)} {asset} sent
         </p>
         <p className="break-all rounded bg-green-100 p-2 font-mono text-xs text-green-900">
           {txHash}
         </p>
         <a
-          href={`https://stellar.expert/explorer/public/tx/${txHash}`}
+          href={`https://stellar.expert/explorer/${STELLAR_EXPERT_NETWORK_SEGMENT}/tx/${txHash}`}
           target="_blank"
           rel="noopener noreferrer"
           className="text-sm text-blue-600 underline"
@@ -104,11 +368,8 @@ export default function StellarCheckout({
 
   return (
     <div className="flex flex-col gap-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
-      <h2 className="text-lg font-semibold text-gray-900">
-        Stellar Checkout
-      </h2>
+      <h2 className="text-lg font-semibold text-gray-900">Stellar Checkout</h2>
 
-      {/* Order summary */}
       <div className="flex flex-col gap-2">
         <h3 className="text-sm font-medium text-gray-600">Order Summary</h3>
         <ul className="divide-y divide-gray-100 rounded-lg border border-gray-100">
@@ -126,77 +387,112 @@ export default function StellarCheckout({
         </ul>
         <div className="flex justify-between px-4 py-2 text-sm font-semibold text-gray-900">
           <span>Total</span>
-          <span>${total.toFixed(2)}</span>
+          <span>
+            {formatAssetAmount(total)} {asset}
+          </span>
         </div>
       </div>
 
-      {/* Asset selector */}
-      <div className="flex flex-col gap-1">
-        <label
-          htmlFor="asset-select"
-          className="text-sm font-medium text-gray-700"
-        >
-          Pay with
-        </label>
-        <select
-          id="asset-select"
-          value={asset}
-          onChange={(e) => setAsset(e.target.value as StellarAsset)}
-          className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-        >
-          <option value="XLM">XLM — Stellar Lumens</option>
-          <option value="USDC">USDC — USD Coin (Stellar)</option>
-          <option value="BITE">BITE — Loyalty Token</option>
-        </select>
-        <p className="text-xs text-gray-500">
-          Amount due: {formatAssetAmount(total, asset)} {asset}
-        </p>
-      </div>
+      {phase === "connect" && (
+        <div className="flex flex-col gap-2 rounded-lg border border-gray-100 bg-gray-50 p-4">
+          <p className="text-sm text-gray-600">
+            Connect a Stellar wallet to pay. On a phone, use a wallet with its
+            own in-app browser (e.g. LOBSTR) or Albedo — Freighter is a
+            desktop browser extension only.
+          </p>
+          <button
+            type="button"
+            onClick={() => void handleConnect()}
+            disabled={busy}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {busy ? "Connecting…" : "Connect Wallet"}
+          </button>
+        </div>
+      )}
 
-      {/* Wallet address */}
-      <div className="flex flex-col gap-1">
-        <label
-          htmlFor="wallet-address"
-          className="text-sm font-medium text-gray-700"
-        >
-          Your Stellar Wallet Address
-        </label>
-        <input
-          id="wallet-address"
-          type="text"
-          value={walletAddress}
-          onChange={(e) => setWalletAddress(e.target.value)}
-          placeholder="GABC...XYZ"
-          className="rounded-lg border border-gray-300 px-3 py-2 font-mono text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-          aria-describedby="wallet-hint"
-        />
-        <p id="wallet-hint" className="text-xs text-gray-500">
-          Must be a valid Stellar public key (starts with G, 56 characters).
+      {phase === "checking-trustline" && (
+        <p className="text-sm text-gray-500">Checking your wallet…</p>
+      )}
+
+      {walletAddress && phase !== "connect" && phase !== "checking-trustline" && (
+        <p className="break-all rounded-lg bg-gray-50 p-2 font-mono text-xs text-gray-500">
+          Connected: {walletAddress}
         </p>
-      </div>
+      )}
+
+      {phase === "needs-trustline" && (
+        <div className="flex flex-col gap-2 rounded-lg border border-amber-200 bg-amber-50 p-4">
+          <p className="text-sm text-amber-800">
+            Your wallet doesn&apos;t trust USDC yet. This is a one-time setup
+            transaction — you&apos;ll be asked to sign it, then you can pay.
+          </p>
+          <button
+            type="button"
+            onClick={() => void handleSetupTrustline()}
+            disabled={busy}
+            className="rounded-lg bg-amber-600 px-4 py-2 text-sm font-medium text-white hover:bg-amber-700 disabled:opacity-50"
+          >
+            Set Up USDC Trustline
+          </button>
+        </div>
+      )}
+
+      {phase === "setting-up-trustline" && (
+        <p className="text-sm text-gray-500">
+          Waiting for your wallet to sign the trustline transaction…
+        </p>
+      )}
+
+      {phase === "paying" && (
+        <p className="text-sm text-gray-500">
+          Waiting for your wallet to sign the payment…
+        </p>
+      )}
+
+      {phase === "confirming" && (
+        <p className="text-sm text-gray-500">
+          Confirming your payment on the Stellar network…
+        </p>
+      )}
 
       {error && (
-        <p role="alert" className="rounded-lg bg-red-50 p-3 text-sm text-red-700">
-          {error}
-        </p>
+        <div role="alert" className="flex flex-col gap-2 rounded-lg bg-red-50 p-3">
+          <p className="text-sm text-red-700">{error.message}</p>
+          {/* Other phases (ready, needs-trustline) already show their own
+              actionable button below — this generic retry only applies when
+              "error" left no other button on screen. */}
+          {phase === "error" && error.retryable && (
+            <button
+              type="button"
+              onClick={handleRetry}
+              className="self-start text-sm font-medium text-red-700 underline"
+            >
+              Try again
+            </button>
+          )}
+        </div>
       )}
 
       <div className="flex gap-3">
         <button
           type="button"
           onClick={onCancel}
-          className="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          disabled={phase === "paying" || phase === "confirming" || phase === "setting-up-trustline"}
+          className="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
         >
           Cancel
         </button>
-        <button
-          type="button"
-          onClick={handleConfirm}
-          disabled={loading}
-          className="flex-1 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
-        >
-          {loading ? "Processing…" : `Pay ${formatAssetAmount(total, asset)} ${asset}`}
-        </button>
+        {phase === "ready" && (
+          <button
+            type="button"
+            onClick={() => void handlePay()}
+            disabled={busy}
+            className="flex-1 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {busy ? "Processing…" : `Pay ${formatAssetAmount(total)} ${asset}`}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/frontend/lib/api/checkoutClient.ts
+++ b/frontend/lib/api/checkoutClient.ts
@@ -1,0 +1,147 @@
+import type {
+  AccountTrustlinesResponse,
+  BuildTrustlineResponse,
+  CheckoutSummaryResponse,
+  InitiatePaymentResponse,
+  PaymentApiErrorBody,
+  PaymentRecordResponse,
+  SubmitSignedPaymentResponse,
+  TrustlineSubmitResponse,
+} from "@/lib/types/payments";
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+
+/**
+ * Diner-facing fetch wrapper, deliberately separate from lib/api/client.ts.
+ * That client authenticates with the staff `auth-token` from localStorage
+ * and redirects to /login on a 401 — neither is correct for a diner who
+ * authenticates with a short-lived, order-scoped checkout token (ADR 0002)
+ * read from the checkout URL, not a staff session.
+ */
+export class CheckoutApiError extends Error {
+  constructor(
+    readonly code: string | undefined,
+    message: string,
+    readonly details?: unknown
+  ) {
+    super(message);
+    this.name = "CheckoutApiError";
+  }
+}
+
+async function checkoutFetch<T>(
+  checkoutToken: string,
+  path: string,
+  init: RequestInit = {}
+): Promise<T> {
+  let response: Response;
+  try {
+    response = await fetch(`${API_BASE_URL}${path}`, {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${checkoutToken}`,
+        ...init.headers,
+      },
+    });
+  } catch {
+    throw new CheckoutApiError(
+      undefined,
+      "Couldn't reach the server. Check your connection and try again."
+    );
+  }
+
+  if (!response.ok) {
+    let body: Partial<PaymentApiErrorBody> = {};
+    try {
+      body = (await response.json()) as Partial<PaymentApiErrorBody>;
+    } catch {
+      // non-JSON error body
+    }
+    throw new CheckoutApiError(
+      body.code,
+      body.message ?? `HTTP ${response.status}`,
+      body.details
+    );
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  return (await response.json()) as T;
+}
+
+export function fetchCheckoutSummary(
+  checkoutToken: string,
+  orderId: string
+): Promise<CheckoutSummaryResponse> {
+  return checkoutFetch(checkoutToken, `/api/orders/${orderId}/checkout-summary`);
+}
+
+export function fetchTrustlines(
+  checkoutToken: string,
+  publicKey: string
+): Promise<AccountTrustlinesResponse> {
+  return checkoutFetch(
+    checkoutToken,
+    `/api/payments/stellar/account/${publicKey}/trustlines`
+  );
+}
+
+export function buildTrustlineTransaction(
+  checkoutToken: string,
+  body: { sourceAccount: string; assetCode: "USDC"; assetIssuer: string }
+): Promise<BuildTrustlineResponse> {
+  return checkoutFetch(checkoutToken, `/api/payments/stellar/account/trustline`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export function submitTrustlineTransaction(
+  checkoutToken: string,
+  signedTransactionXdr: string
+): Promise<TrustlineSubmitResponse> {
+  return checkoutFetch(
+    checkoutToken,
+    `/api/payments/stellar/account/trustline/submit`,
+    { method: "POST", body: JSON.stringify({ signedTransactionXdr }) }
+  );
+}
+
+export function initiatePayment(
+  checkoutToken: string,
+  body: {
+    orderId: string;
+    sourceAccount: string;
+    assetCode: "XLM" | "USDC";
+    assetIssuer?: string;
+    amount: string;
+    idempotencyKey: string;
+  }
+): Promise<InitiatePaymentResponse> {
+  return checkoutFetch(checkoutToken, `/api/payments/stellar/initiate`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export function submitSignedPayment(
+  checkoutToken: string,
+  paymentId: string,
+  signedTransactionXdr: string
+): Promise<SubmitSignedPaymentResponse> {
+  return checkoutFetch(
+    checkoutToken,
+    `/api/payments/stellar/${paymentId}/submit-signed`,
+    { method: "POST", body: JSON.stringify({ signedTransactionXdr }) }
+  );
+}
+
+export function fetchPaymentStatus(
+  checkoutToken: string,
+  paymentId: string
+): Promise<PaymentRecordResponse> {
+  return checkoutFetch(checkoutToken, `/api/payments/stellar/${paymentId}`);
+}

--- a/frontend/lib/stellar/wallet.ts
+++ b/frontend/lib/stellar/wallet.ts
@@ -1,0 +1,128 @@
+import {
+  AlbedoModule,
+  FreighterModule,
+  LobstrModule,
+  Networks,
+  StellarWalletsKit,
+} from "@creit.tech/stellar-wallets-kit";
+
+/**
+ * Only the three wallets the issue asks for (Freighter/Albedo/LOBSTR) —
+ * deliberately not `allowAllModules()`. That set pulls in WalletConnect,
+ * hardware-wallet, and other bridge modules that need their own
+ * configuration (e.g. a WalletConnect project ID) this app doesn't have.
+ *
+ * Freighter is a desktop browser extension; it has no mobile presence, so a
+ * diner scanning a table QR code on their phone won't see it as available.
+ * That's a real, documented gap rather than a silent one — LOBSTR (a Stellar
+ * wallet with its own in-app browser) and Albedo (works from any mobile
+ * browser via a web popup) are the mobile-viable options in this set.
+ */
+function buildModules() {
+  return [new FreighterModule(), new AlbedoModule(), new LobstrModule()];
+}
+
+function resolveNetwork(): Networks {
+  const network = (
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? "testnet"
+  ).toLowerCase();
+
+  switch (network) {
+    case "public":
+    case "mainnet":
+      return Networks.PUBLIC;
+    case "testnet":
+      return Networks.TESTNET;
+    case "futurenet":
+      return Networks.FUTURENET;
+    default:
+      throw new Error(
+        `Unrecognized NEXT_PUBLIC_STELLAR_NETWORK "${network}" (expected one of: public, testnet, futurenet)`
+      );
+  }
+}
+
+export class WalletError extends Error {
+  constructor(
+    readonly kind: "wallet_rejected" | "wallet_unavailable" | "unknown",
+    message: string
+  ) {
+    super(message);
+    this.name = "WalletError";
+  }
+}
+
+// The kit throws plain `{ code, message }` objects (see IKitError), not
+// Error instances, for user-facing failures like "the user closed the
+// modal" or a wallet declining a signature request. There's no stable
+// `code` shared across every underlying wallet for "user rejected" (each
+// wallet's own extension/API surfaces its own), so this is a best-effort
+// message match rather than a switch on a code.
+function classifyKitError(error: unknown): WalletError {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "object" && error !== null && "message" in error
+        ? String((error as { message?: unknown }).message ?? "")
+        : String(error);
+
+  const normalized = message.toLowerCase();
+  if (
+    normalized.includes("reject") ||
+    normalized.includes("declin") ||
+    normalized.includes("denied") ||
+    normalized.includes("closed the modal") ||
+    normalized.includes("cancel")
+  ) {
+    return new WalletError("wallet_rejected", message);
+  }
+
+  return new WalletError("unknown", message || "The wallet request failed.");
+}
+
+let initialized = false;
+
+function ensureInitialized(): void {
+  if (initialized) return;
+  StellarWalletsKit.init({
+    network: resolveNetwork(),
+    modules: buildModules(),
+  });
+  initialized = true;
+}
+
+/** Opens the wallet-picker modal and returns the connected public key. */
+export async function connectWallet(): Promise<{ address: string }> {
+  ensureInitialized();
+  try {
+    return await StellarWalletsKit.authModal();
+  } catch (error) {
+    throw classifyKitError(error);
+  }
+}
+
+/** Asks the connected wallet to sign an unsigned XDR envelope. */
+export async function signTransactionXdr(
+  xdr: string,
+  address: string
+): Promise<string> {
+  ensureInitialized();
+  try {
+    const { signedTxXdr } = await StellarWalletsKit.signTransaction(xdr, {
+      address,
+      networkPassphrase: resolveNetwork(),
+    });
+    return signedTxXdr;
+  } catch (error) {
+    throw classifyKitError(error);
+  }
+}
+
+export async function disconnectWallet(): Promise<void> {
+  if (!initialized) return;
+  try {
+    await StellarWalletsKit.disconnect();
+  } catch {
+    // Best-effort — the diner is leaving the checkout flow either way.
+  }
+}

--- a/frontend/lib/stellar/wallet.ts
+++ b/frontend/lib/stellar/wallet.ts
@@ -1,10 +1,10 @@
-import {
-  AlbedoModule,
-  FreighterModule,
-  LobstrModule,
-  Networks,
-  StellarWalletsKit,
-} from "@creit.tech/stellar-wallets-kit";
+import { Networks, StellarWalletsKit } from "@creit.tech/stellar-wallets-kit";
+// Each wallet module is its own subpath export (see the package's "exports"
+// map) — the root package only re-exports the kit itself, not every wallet
+// module, so importing these from the bare package name fails to resolve.
+import { AlbedoModule } from "@creit.tech/stellar-wallets-kit/modules/albedo";
+import { FreighterModule } from "@creit.tech/stellar-wallets-kit/modules/freighter";
+import { LobstrModule } from "@creit.tech/stellar-wallets-kit/modules/lobstr";
 
 /**
  * Only the three wallets the issue asks for (Freighter/Albedo/LOBSTR) —

--- a/frontend/lib/types/payments.ts
+++ b/frontend/lib/types/payments.ts
@@ -1,0 +1,83 @@
+// Diner-facing checkout types — mirrors the backend's payments/orders DTOs
+// (backend/src/modules/payments, backend/src/modules/orders). Kept separate
+// from lib/types/api.ts, which is admin/staff-facing only.
+
+export type PaymentAssetCode = "XLM" | "USDC";
+
+export type PaymentStatus =
+  | "pending"
+  | "submitted"
+  | "confirmed"
+  | "failed"
+  | "expired";
+
+// Mirrors backend/src/modules/payments/errors/payment.errors.ts PaymentErrorCode.
+export type PaymentErrorCode =
+  | "INSUFFICIENT_BALANCE"
+  | "MISSING_TRUSTLINE"
+  | "SEQUENCE_CONFLICT"
+  | "MALFORMED_REQUEST"
+  | "IDEMPOTENCY_CONFLICT"
+  | "RESTAURANT_WALLET_NOT_CONFIGURED"
+  | "SUBMISSION_FAILED";
+
+export interface CheckoutOrderLineItem {
+  name: string;
+  quantity: number;
+  price: number;
+}
+
+export interface CheckoutSummaryResponse {
+  orderId: string;
+  orderNumber: string;
+  items: CheckoutOrderLineItem[];
+  total: number;
+  currency: string;
+  status: string;
+}
+
+export interface TrustlineBalance {
+  assetCode: string;
+  assetIssuer: string | null;
+  balance: string;
+}
+
+export interface AccountTrustlinesResponse {
+  funded: boolean;
+  balances: TrustlineBalance[];
+}
+
+export interface BuildTrustlineResponse {
+  unsignedTransactionXdr: string;
+}
+
+export interface TrustlineSubmitResponse {
+  successful: boolean;
+  hash: string;
+}
+
+export interface InitiatePaymentResponse {
+  paymentId: string;
+  status: PaymentStatus;
+  unsignedTransactionXdr: string;
+}
+
+export interface SubmitSignedPaymentResponse {
+  paymentId: string;
+  status: PaymentStatus;
+  stellarTxHash: string | null;
+}
+
+export interface PaymentRecordResponse {
+  id: string;
+  orderId: string;
+  status: PaymentStatus;
+  stellarTxHash: string | null;
+  failureReason: PaymentErrorCode | null;
+}
+
+export interface PaymentApiErrorBody {
+  code?: PaymentErrorCode;
+  message: string;
+  details?: unknown;
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@creit.tech/stellar-wallets-kit": "^2.5.0",
         "@dnd-kit/core": "^6.3.1",
         "@hookform/resolvers": "^5.2.2",
         "@tanstack/react-query": "^5.90.19",
@@ -53,6 +54,18 @@
         "typescript": "5.9.3"
       }
     },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@albedo-link/intent": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@albedo-link/intent/-/intent-0.12.0.tgz",
+      "integrity": "sha512-UlGBhi0qASDYOjLrOL4484vQ26Ee3zTK2oAgvPMClOs+1XNk3zbs3dECKZv+wqeSI8SkHow8mXLTa16eVh+dQA==",
+      "license": "MIT"
+    },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
@@ -64,6 +77,501 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@base-org/account": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@base-org/account/-/account-2.4.0.tgz",
+      "integrity": "sha512-A4Umpi8B9/pqR78D1Yoze4xHyQaujioVRqqO3d6xuDFw9VRtjg6tK3bPlwE0aW+nVH/ntllCpPa2PbI8Rnjcug==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@coinbase/cdp-sdk": "^1.0.0",
+        "@noble/hashes": "1.4.0",
+        "clsx": "1.2.1",
+        "eventemitter3": "5.0.1",
+        "idb-keyval": "6.2.1",
+        "ox": "0.6.9",
+        "preact": "10.24.2",
+        "viem": "^2.31.7",
+        "zustand": "5.0.3"
+      }
+    },
+    "node_modules/@base-org/account/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@base-org/account/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@base-org/account/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@base-org/account/node_modules/preact": {
+      "version": "10.24.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.2.tgz",
+      "integrity": "sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/@base-org/account/node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.14.0.tgz",
+      "integrity": "sha512-C3UGsiCwSprE2NKIIFA3hCDlpXTMCAXRZuEVp88L1GY36Y41+rYL5fryE+nOFhp4p4JPQvdV8PQ4DWgHgeTE+w==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@coinbase/cdp-sdk": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@coinbase/cdp-sdk/-/cdp-sdk-1.55.0.tgz",
+      "integrity": "sha512-5PbUg3n3Jk9nm8nEStskRv6jTrVZKkgwxMFjW+i/xUDDzK1fXksKwXdjgUiHB1hf0FZx1LiYBosrh4IULxFyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana-program/system": "^0.10.0",
+        "@solana-program/token": "^0.9.0",
+        "@solana/kit": "^5.5.1",
+        "abitype": "1.0.6",
+        "axios": "1.16.0",
+        "axios-retry": "^4.5.0",
+        "bs58": "^6.0.0",
+        "jose": "^6.2.0",
+        "md5": "^2.3.0",
+        "uncrypto": "^0.1.3",
+        "viem": "^2.47.0",
+        "zod": "^3.25.76"
+      },
+      "peerDependencies": {
+        "@x402/core": "^2.21.0",
+        "@x402/evm": "^2.21.0",
+        "@x402/extensions": "^2.21.0",
+        "@x402/svm": "^2.21.0"
+      },
+      "peerDependenciesMeta": {
+        "@x402/core": {
+          "optional": true
+        },
+        "@x402/evm": {
+          "optional": true
+        },
+        "@x402/extensions": {
+          "optional": true
+        },
+        "@x402/svm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@coinbase/cdp-sdk/node_modules/abitype": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.6.tgz",
+      "integrity": "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3 >=3.22.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@coinbase/cdp-sdk/node_modules/jose": {
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@coinbase/wallet-sdk": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-4.3.6.tgz",
+      "integrity": "sha512-4q8BNG1ViL4mSAAvPAtpwlOs1gpC+67eQtgIwNvT3xyeyFFd+guwkc8bcX5rTmQhXpqnhzC4f0obACbP9CqMSA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@noble/hashes": "1.4.0",
+        "clsx": "1.2.1",
+        "eventemitter3": "5.0.1",
+        "idb-keyval": "6.2.1",
+        "ox": "0.6.9",
+        "preact": "10.24.2",
+        "viem": "^2.27.2",
+        "zustand": "5.0.3"
+      }
+    },
+    "node_modules/@coinbase/wallet-sdk/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@coinbase/wallet-sdk/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@coinbase/wallet-sdk/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@coinbase/wallet-sdk/node_modules/preact": {
+      "version": "10.24.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.2.tgz",
+      "integrity": "sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/@coinbase/wallet-sdk/node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@creit.tech/stellar-wallets-kit/-/stellar-wallets-kit-2.5.0.tgz",
+      "integrity": "sha512-pqVSr968QChZ5e2jj3LOoBTPkjbFck/6llQHICX5tIhPnyEuuREL8JmGoNalG5rVSWmcsi1OxoevNiLYWqlbYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@albedo-link/intent": "0.12.0",
+        "@creit.tech/xbull-wallet-connect": "0.4.0",
+        "@hot-wallet/sdk": "1.0.11",
+        "@ledgerhq/hw-app-str": "7.2.8",
+        "@ledgerhq/hw-transport": "6.31.12",
+        "@ledgerhq/hw-transport-webusb": "6.29.12",
+        "@lobstrco/signer-extension-api": "2.0.0",
+        "@preact/signals": "2.9.0",
+        "@reown/appkit": "1.8.21",
+        "@stellar/freighter-api": "6.0.0",
+        "@stellar/stellar-sdk": "^16.0.0",
+        "@trezor/connect-plugin-stellar": "10.0.0-alpha.1",
+        "@trezor/connect-web": "10.0.0-alpha.1",
+        "@twind/core": "1.1.3",
+        "@twind/preset-autoprefix": "1.0.7",
+        "@twind/preset-tailwind": "1.1.4",
+        "@walletconnect/sign-client": "2.23.0",
+        "@walletconnect/types": "2.23.9",
+        "htm": "3.1.1",
+        "preact": "^10.29.0"
+      }
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/@noble/hashes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
+      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/@stellar/js-xdr": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-4.0.0.tgz",
+      "integrity": "sha512-+NmNa7Tk5BI5XFdy/6xGTqAN4J9a9KgCrCGhj2uEUTCBhLkch0M+QbKzNH8zEnejWe0p8w+0q5hUVX6L3OzoVA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0",
+        "pnpm": ">=9.0.0"
+      }
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/@stellar/stellar-sdk": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-16.2.0.tgz",
+      "integrity": "sha512-FV/Rm11QvrFzR5X9fIfb6Pg30KyYyrRkNezELGFmYDAYrzoPTjqo7vklnEPd2HEontzjJmZizWk8CjyIh5vp0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/ed25519": "^3.1.0",
+        "@noble/hashes": "^2.2.0",
+        "@stellar/js-xdr": "4.0.0",
+        "axios": "1.18.0",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^11.1.4",
+        "buffer": "^6.0.3",
+        "commander": "^14.0.3",
+        "eventsource": "^4.1.0",
+        "feaxios": "^0.0.23",
+        "smol-toml": "^1.6.1",
+        "uint8array-extras": "^1.5.0"
+      },
+      "bin": {
+        "stellar-js": "bin/stellar-js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/@twind/core": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@twind/core/-/core-1.1.3.tgz",
+      "integrity": "sha512-/B/aNFerMb2IeyjSJy3SJxqVxhrT77gBDknLMiZqXIRr4vNJqiuhx7KqUSRzDCwUmyGuogkamz+aOLzN6MeSLw==",
+      "funding": [
+        {
+          "type": "Open Collective",
+          "url": "https://opencollective.com/twind"
+        },
+        {
+          "type": "Github Sponsor",
+          "url": "https://github.com/sponsors/tw-in-js"
+        },
+        {
+          "type": "Ko-fi",
+          "url": "https://ko-fi.com/twind"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "typescript": "^4.8.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/@twind/preset-autoprefix": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@twind/preset-autoprefix/-/preset-autoprefix-1.0.7.tgz",
+      "integrity": "sha512-3wmHO0pG/CVxYBNZUV0tWcL7CP0wD5KpyWAQE/KOalWmOVBj+nH6j3v6Y3I3pRuMFaG5DC78qbYbhA1O11uG3w==",
+      "funding": [
+        {
+          "type": "Open Collective",
+          "url": "https://opencollective.com/twind"
+        },
+        {
+          "type": "Github Sponsor",
+          "url": "https://github.com/sponsors/tw-in-js"
+        },
+        {
+          "type": "Ko-fi",
+          "url": "https://ko-fi.com/twind"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "style-vendorizer": "^2.2.3"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "@twind/core": "^1.1.0",
+        "typescript": "^4.8.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/@twind/preset-tailwind": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@twind/preset-tailwind/-/preset-tailwind-1.1.4.tgz",
+      "integrity": "sha512-zv85wrP/DW4AxgWrLfH7kyGn/KJF3K04FMLVl2AjoxZGYdCaoZDkL8ma3hzaKQ+WGgBFRubuB/Ku2Rtv/wjzVw==",
+      "funding": [
+        {
+          "type": "Open Collective",
+          "url": "https://opencollective.com/twind"
+        },
+        {
+          "type": "Github Sponsor",
+          "url": "https://github.com/sponsors/tw-in-js"
+        },
+        {
+          "type": "Ko-fi",
+          "url": "https://ko-fi.com/twind"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "@twind/core": "^1.1.0",
+        "typescript": "^4.8.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/axios": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/bignumber.js": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-11.1.5.tgz",
+      "integrity": "sha512-6WmzCNtUnfKpbozq+hOgWaZMMzORmYBwF1xZScyoIX3QRYWeKTtxxwDOW5tIz7C9BdjkIYHGTcelCLkXg0mndw==",
+      "license": "MIT"
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/eventsource": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.1.1.tgz",
+      "integrity": "sha512-D6bTRWh6KahHTK/m4WnjPQyEinNPf9eFLEZSEoj7d6fTibspnAVYfzHvirL7u/aoX5d9YYfIkBVAhmigUELk9w==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@creit.tech/xbull-wallet-connect": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@creit.tech/xbull-wallet-connect/-/xbull-wallet-connect-0.4.0.tgz",
+      "integrity": "sha512-LrCUIqUz50SkZ4mv2hTqSmwews8CNRYVoZ9+VjLsK/1U8PByzXTxv1vZyenj6avRTG86ifpoeihz7D3D5YIDrQ==",
+      "dependencies": {
+        "rxjs": "^7.5.5",
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.1"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -137,6 +645,18 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@emurgo/cardano-serialization-lib-browser": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-browser/-/cardano-serialization-lib-browser-13.2.1.tgz",
+      "integrity": "sha512-7RfX1gI16Vj2DgCp/ZoXqyLAakWo6+X95ku/rYGbVzuS/1etrlSiJmdbmdm+eYmszMlGQjrtOJQeVLXoj4L/Ag==",
+      "license": "MIT"
+    },
+    "node_modules/@emurgo/cardano-serialization-lib-nodejs": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-nodejs/-/cardano-serialization-lib-nodejs-13.2.0.tgz",
+      "integrity": "sha512-Bz1zLGEqBQ0BVkqt1OgMxdBOE3BdUWUd7Ly9Ecr/aUwkA8AV1w1XzBMe4xblmJHnB1XXNlPH4SraXCvO+q0Mig==",
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -282,6 +802,122 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@ethereumjs/common": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-10.1.3.tgz",
+      "integrity": "sha512-ECWwbc4s8Ji7U0mkfZP6gIDy1FxXe0ZyVOTt0adkztPQRzX2DbH2ul7a83DSS8qYAiG6//vVXMkP60TyYOnv8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@ethereumjs/util": "^10.1.3",
+        "eventemitter3": "^5.0.1"
+      }
+    },
+    "node_modules/@ethereumjs/rlp": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-10.1.3.tgz",
+      "integrity": "sha512-d795YWkN6O8EJh/PgJ2zZKCdBMl8OlqkuVQESoidH666gaFtUuJ01jDtiuqfyOqTNcTdGhHi8LkQv1WEZzvZZw==",
+      "license": "MPL-2.0",
+      "bin": {
+        "rlp": "bin/rlp.cjs"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ethereumjs/tx": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-10.1.3.tgz",
+      "integrity": "sha512-5uk9qB2MjyF4axL6GGPvYODe3uR/h6k36boDbvjH81WYFphw/JAIrI1thkWQX4BCyF8bi6suxORhi+vDc3lPlg==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@ethereumjs/common": "^10.1.3",
+        "@ethereumjs/rlp": "^10.1.3",
+        "@ethereumjs/util": "^10.1.3",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ethereumjs/tx/node_modules/@noble/curves": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.3.0.tgz",
+      "integrity": "sha512-v7cY+4oWYPQszRj6ZFGzTVL7uP2TaLo1xMhWHzYC5wj0ZhOXQ5x+sBre8rF3hi8cAoi0bh1qXoovoOkdFtvqEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.3.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@ethereumjs/tx/node_modules/@noble/hashes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
+      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@ethereumjs/util": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-10.1.3.tgz",
+      "integrity": "sha512-PhezOVe4DFaC+QLIsnK/tiOaXjpjS2F9AH4Ez0EfWevFw9NWNSg95l7I0dWuHF0B7v9odm2Ijqwo0EnARXtUmA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@ethereumjs/rlp": "^10.1.3",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ethereumjs/util/node_modules/@noble/curves": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.3.0.tgz",
+      "integrity": "sha512-v7cY+4oWYPQszRj6ZFGzTVL7uP2TaLo1xMhWHzYC5wj0ZhOXQ5x+sBre8rF3hi8cAoi0bh1qXoovoOkdFtvqEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.3.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@ethereumjs/util/node_modules/@noble/hashes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
+      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@fivebinaries/coin-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@fivebinaries/coin-selection/-/coin-selection-3.0.0.tgz",
+      "integrity": "sha512-h25Pn1ZA7oqQBQDodGAgIsQt66T2wDge9onBKNqE66WNWL0KJiKJbpij8YOLo5AAlEIg5IS7EB1QjBgDOIg6DQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@emurgo/cardano-serialization-lib-browser": "^13.2.0",
+        "@emurgo/cardano-serialization-lib-nodejs": "13.2.0"
+      }
+    },
     "node_modules/@hookform/resolvers": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
@@ -292,6 +928,22 @@
       },
       "peerDependencies": {
         "react-hook-form": "^7.55.0"
+      }
+    },
+    "node_modules/@hot-wallet/sdk": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@hot-wallet/sdk/-/sdk-1.0.11.tgz",
+      "integrity": "sha512-qRDH/4yqnRCnk7L/Qd0/LDOKDUKWcFgvf6eRELJkP0OgxIe65i/iXaG+u2lL0mLbTGkiWYk67uAvEerNUv2gzA==",
+      "dependencies": {
+        "@near-js/crypto": "^1.4.0",
+        "@near-js/utils": "^1.0.0",
+        "@near-wallet-selector/core": "^8.9.13",
+        "@solana/wallet-adapter-base": "^0.9.23",
+        "@solana/web3.js": "^1.95.0",
+        "borsh": "^2.0.0",
+        "js-sha256": "^0.11.0",
+        "sha1": "^1.1.1",
+        "uuid4": "^2.0.3"
       }
     },
     "node_modules/@humanfs/core": {
@@ -861,6 +1513,114 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@ledgerhq/devices": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.6.1.tgz",
+      "integrity": "sha512-PQR2fyWz7P/wMFHY9ZLz17WgFdxC/Im0RVDcWXpp24+iRQRyxhQeX2iG4mBKUzfaAW6pOIEiWt+vmJh88QP9rQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/errors": "^6.26.0",
+        "@ledgerhq/logs": "^6.13.0",
+        "rxjs": "^7.8.1",
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/@ledgerhq/errors": {
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.37.0.tgz",
+      "integrity": "sha512-T5yiKI5UX7ugeocdTF3TUsCIN2BH41Bio4ZeN410YFjFOf3es08n/5JyMzzKwzRgP0blG3HfBf7s7vJKqCSAeg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@ledgerhq/hw-app-str": {
+      "version": "7.2.8",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-str/-/hw-app-str-7.2.8.tgz",
+      "integrity": "sha512-VHICY9jyZW5LM/8zc/mSbW7fS2bAC1OTVOtRwdQLEDn6Gv9UaNcCWjaHI1UKAnDUqYX7DUQuIPiTP1b4O+mtUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/errors": "^6.26.0",
+        "@ledgerhq/hw-transport": "^6.31.12",
+        "bip32-path": "^0.4.2"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport": {
+      "version": "6.31.12",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.31.12.tgz",
+      "integrity": "sha512-FO5LRIXYC8ELtaohlO8qK0b3TfHUNBZ3+CXKPHiHj2jJwrxPf4s5kcgBYrmzuf1C/1vfrMOjzyty6OgrMIbU6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/devices": "8.6.1",
+        "@ledgerhq/errors": "^6.26.0",
+        "@ledgerhq/logs": "^6.13.0",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-webusb": {
+      "version": "6.29.12",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-6.29.12.tgz",
+      "integrity": "sha512-mMGKPYAUz9MNcURe+hSTSHwqPwCli6D0lCl15Z4hDOpcqhZ26vwoeWVKeQp53NNCetHOl0lauPkN43Gt9pIggg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ledgerhq/devices": "8.6.1",
+        "@ledgerhq/errors": "^6.26.0",
+        "@ledgerhq/hw-transport": "^6.31.12",
+        "@ledgerhq/logs": "^6.13.0"
+      }
+    },
+    "node_modules/@ledgerhq/logs": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.17.0.tgz",
+      "integrity": "sha512-yra33g5q/AU7+PwAws+GaVpQGUuxnDREjVBnviJjcaJLVKuLzI4pnj8Bd3nY3fypM5k1yZEYKEXfUuGFUjP2+w==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/react": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.8.tgz",
+      "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peerDependencies": {
+        "@types/react": "17 || 18 || 19"
+      }
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@lobstrco/signer-extension-api": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@lobstrco/signer-extension-api/-/signer-extension-api-2.0.0.tgz",
+      "integrity": "sha512-jwlVyzMFF296iaNgMWn1lu+EU6BeUD4mgPurEsy8EygYNCrjA8igLpsDlXhfvXhst9tX5w4wRuTDX+FZtpfCug==",
+      "license": "GPL-3.0"
+    },
+    "node_modules/@mobily/ts-belt": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@mobily/ts-belt/-/ts-belt-3.13.1.tgz",
+      "integrity": "sha512-K5KqIhPI/EoCTbA6CGbrenM9s41OouyK8A03fGJJcla/zKucsgLbz8HNbeseoLarRPgyWJsUyCYqFhI7t3Ra9Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.*"
+      }
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.2.tgz",
+      "integrity": "sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -872,6 +1632,244 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@near-js/accounts": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@near-js/accounts/-/accounts-1.4.1.tgz",
+      "integrity": "sha512-ni3QT9H3NdrbVVKyx56yvz93r89Dvpc/vgVtiIK2OdXjkK6jcj+UKMDRQ6F7rd9qJOInLkHZbVBtcR6j1CXLjw==",
+      "license": "ISC",
+      "dependencies": {
+        "@near-js/crypto": "1.4.2",
+        "@near-js/providers": "1.0.3",
+        "@near-js/signers": "0.2.2",
+        "@near-js/transactions": "1.3.3",
+        "@near-js/types": "0.3.1",
+        "@near-js/utils": "1.1.0",
+        "@noble/hashes": "1.7.1",
+        "borsh": "1.0.0",
+        "depd": "2.0.0",
+        "is-my-json-valid": "^2.20.6",
+        "lru_map": "0.4.1",
+        "near-abi": "0.2.0"
+      }
+    },
+    "node_modules/@near-js/accounts/node_modules/borsh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
+      "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@near-js/crypto": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@near-js/crypto/-/crypto-1.4.2.tgz",
+      "integrity": "sha512-GRfchsyfWvSAPA1gI9hYhw5FH94Ac1BUo+Cmp5rSJt/V0K3xVzCWgOQxvv4R3kDnWjaXJEuAmpEEnr4Bp3FWrA==",
+      "license": "ISC",
+      "dependencies": {
+        "@near-js/types": "0.3.1",
+        "@near-js/utils": "1.1.0",
+        "@noble/curves": "1.8.1",
+        "borsh": "1.0.0",
+        "randombytes": "2.1.0",
+        "secp256k1": "5.0.1"
+      }
+    },
+    "node_modules/@near-js/crypto/node_modules/borsh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
+      "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@near-js/keystores": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@near-js/keystores/-/keystores-0.2.2.tgz",
+      "integrity": "sha512-DLhi/3a4qJUY+wgphw2Jl4S+L0AKsUYm1mtU0WxKYV5OBwjOXvbGrXNfdkheYkfh3nHwrQgtjvtszX6LrRXLLw==",
+      "license": "ISC",
+      "dependencies": {
+        "@near-js/crypto": "1.4.2",
+        "@near-js/types": "0.3.1"
+      }
+    },
+    "node_modules/@near-js/keystores-browser": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@near-js/keystores-browser/-/keystores-browser-0.2.2.tgz",
+      "integrity": "sha512-Pxqm7WGtUu6zj32vGCy9JcEDpZDSB5CCaLQDTQdF3GQyL0flyRv2I/guLAgU5FLoYxU7dJAX9mslJhPW7P2Bfw==",
+      "license": "ISC",
+      "dependencies": {
+        "@near-js/crypto": "1.4.2",
+        "@near-js/keystores": "0.2.2"
+      }
+    },
+    "node_modules/@near-js/keystores-node": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@near-js/keystores-node/-/keystores-node-0.1.2.tgz",
+      "integrity": "sha512-MWLvTszZOVziiasqIT/LYNhUyWqOJjDGlsthOsY6dTL4ZcXjjmhmzrbFydIIeQr+CcEl5wukTo68ORI9JrHl6g==",
+      "license": "ISC",
+      "dependencies": {
+        "@near-js/crypto": "1.4.2",
+        "@near-js/keystores": "0.2.2"
+      }
+    },
+    "node_modules/@near-js/providers": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@near-js/providers/-/providers-1.0.3.tgz",
+      "integrity": "sha512-VJMboL14R/+MGKnlhhE3UPXCGYvMd1PpvF9OqZ9yBbulV7QVSIdTMfY4U1NnDfmUC2S3/rhAEr+3rMrIcNS7Fg==",
+      "license": "ISC",
+      "dependencies": {
+        "@near-js/transactions": "1.3.3",
+        "@near-js/types": "0.3.1",
+        "@near-js/utils": "1.1.0",
+        "borsh": "1.0.0",
+        "exponential-backoff": "^3.1.2"
+      },
+      "optionalDependencies": {
+        "node-fetch": "2.6.7"
+      }
+    },
+    "node_modules/@near-js/providers/node_modules/borsh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
+      "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@near-js/providers/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@near-js/signers": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@near-js/signers/-/signers-0.2.2.tgz",
+      "integrity": "sha512-M6ib+af9zXAPRCjH2RyIS0+RhCmd9gxzCeIkQ+I2A3zjgGiEDkBZbYso9aKj8Zh2lPKKSH7h+u8JGymMOSwgyw==",
+      "license": "ISC",
+      "dependencies": {
+        "@near-js/crypto": "1.4.2",
+        "@near-js/keystores": "0.2.2",
+        "@noble/hashes": "1.3.3"
+      }
+    },
+    "node_modules/@near-js/signers/node_modules/@noble/hashes": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@near-js/transactions": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@near-js/transactions/-/transactions-1.3.3.tgz",
+      "integrity": "sha512-1AXD+HuxlxYQmRTLQlkVmH+RAmV3HwkAT8dyZDu+I2fK/Ec9BQHXakOJUnOBws3ihF+akQhamIBS5T0EXX/Ylw==",
+      "license": "ISC",
+      "dependencies": {
+        "@near-js/crypto": "1.4.2",
+        "@near-js/signers": "0.2.2",
+        "@near-js/types": "0.3.1",
+        "@near-js/utils": "1.1.0",
+        "@noble/hashes": "1.7.1",
+        "borsh": "1.0.0"
+      }
+    },
+    "node_modules/@near-js/transactions/node_modules/borsh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
+      "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@near-js/types": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@near-js/types/-/types-0.3.1.tgz",
+      "integrity": "sha512-8qIA7ynAEAuVFNAQc0cqz2xRbfyJH3PaAG5J2MgPPhD18lu/tCGd6pzYg45hjhtiJJRFDRjh/FUWKS+ZiIIxUw==",
+      "license": "ISC"
+    },
+    "node_modules/@near-js/utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@near-js/utils/-/utils-1.1.0.tgz",
+      "integrity": "sha512-5XWRq7xpu8Wud9pRXe2U347KXyi0mXofedUY2DQ9TaqiZUcMIaN9xj7DbCs2v6dws3pJyYrT1KWxeNp5fSaY3w==",
+      "license": "ISC",
+      "dependencies": {
+        "@near-js/types": "0.3.1",
+        "@scure/base": "^1.2.0",
+        "depd": "2.0.0",
+        "mustache": "4.0.0"
+      }
+    },
+    "node_modules/@near-js/wallet-account": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@near-js/wallet-account/-/wallet-account-1.3.3.tgz",
+      "integrity": "sha512-GDzg/Kz0GBYF7tQfyQQQZ3vviwV8yD+8F2lYDzsWJiqIln7R1ov0zaXN4Tii86TeS21KPn2hHAsVu3Y4txa8OQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@near-js/accounts": "1.4.1",
+        "@near-js/crypto": "1.4.2",
+        "@near-js/keystores": "0.2.2",
+        "@near-js/providers": "1.0.3",
+        "@near-js/signers": "0.2.2",
+        "@near-js/transactions": "1.3.3",
+        "@near-js/types": "0.3.1",
+        "@near-js/utils": "1.1.0",
+        "borsh": "1.0.0"
+      }
+    },
+    "node_modules/@near-js/wallet-account/node_modules/borsh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
+      "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@near-wallet-selector/core": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/@near-wallet-selector/core/-/core-8.10.2.tgz",
+      "integrity": "sha512-MH8sg6XHyylq2ZXxnOjrKHMCmuRgFfpfdC816fW0R8hctZiXZ0lmfLvgG1xfA2BAxrVytiU1g3dcE97/P5cZqg==",
+      "dependencies": {
+        "borsh": "1.0.0",
+        "events": "3.3.0",
+        "js-sha256": "0.9.0",
+        "rxjs": "7.8.1"
+      },
+      "peerDependencies": {
+        "near-api-js": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/@near-wallet-selector/core/node_modules/borsh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
+      "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@near-wallet-selector/core/node_modules/js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
+      "license": "MIT"
+    },
+    "node_modules/@near-wallet-selector/core/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@next/env": {
@@ -1018,6 +2016,54 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.7.1"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-3.1.0.tgz",
+      "integrity": "sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1066,6 +2112,104 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@phosphor-icons/webcomponents": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/webcomponents/-/webcomponents-2.1.5.tgz",
+      "integrity": "sha512-JcvQkZxvcX2jK+QCclm8+e8HXqtdFW9xV4/kk2aL9Y3dJA2oQVt+pzbv1orkumz3rfx4K9mn9fDoMr1He1yr7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lit": "^3"
+      }
+    },
+    "node_modules/@preact/signals": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.9.0.tgz",
+      "integrity": "sha512-hYrY0KyUqkDgOl1qba/JGn6y81pXnurn21PMaxfcMwdncdZ3M/oVdmpTvEnsGjh48dIwDVc7bjWHqIsngSjYug==",
+      "license": "MIT",
+      "dependencies": {
+        "@preact/signals-core": "^1.14.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact": ">= 10.25.0 || >=11.0.0-0"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+      "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
@@ -1102,6 +2246,166 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/@reown/appkit": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.8.21.tgz",
+      "integrity": "sha512-+6IRUBc9cgXKhNHzxlzxEp7nL1Jx/lcYgHdqwD10O7MPzU2/Ao5/epwt5vqn1nUlwyI6Awm/YCUWIa0Zg5RVEA==",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.21",
+        "@reown/appkit-controllers": "1.8.21",
+        "@reown/appkit-pay": "1.8.21",
+        "@reown/appkit-polyfills": "1.8.21",
+        "@reown/appkit-scaffold-ui": "1.8.21",
+        "@reown/appkit-ui": "1.8.21",
+        "@reown/appkit-utils": "1.8.21",
+        "@reown/appkit-wallet": "1.8.21",
+        "@walletconnect/universal-provider": "2.23.7",
+        "bs58": "6.0.0",
+        "semver": "7.7.2",
+        "valtio": "2.1.7",
+        "viem": ">=2.45.0"
+      },
+      "optionalDependencies": {
+        "@lit/react": "1.0.8"
+      }
+    },
+    "node_modules/@reown/appkit-common": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.21.tgz",
+      "integrity": "sha512-FigrZbke9dHVdc4GjG4JNqClIN58gOhREugLx2oEBUFD2e3oQNvX2gcjoUDM2yP0ZAaIEYJOXwjw4sbBU4gzLQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "big.js": "6.2.2",
+        "dayjs": "1.11.13",
+        "viem": ">=2.45.0"
+      }
+    },
+    "node_modules/@reown/appkit-controllers": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.21.tgz",
+      "integrity": "sha512-2xh64lhPb+p0pwKQDQXpokUGqklB+xWD0JpfBvMVEZxeYzKXyJ7piRBB45TH01Etyitkh5Fh4pzBYz4gbIZSog==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.21",
+        "@reown/appkit-wallet": "1.8.21",
+        "@walletconnect/universal-provider": "2.23.7",
+        "valtio": "2.1.7",
+        "viem": ">=2.45.0"
+      }
+    },
+    "node_modules/@reown/appkit-pay": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.8.21.tgz",
+      "integrity": "sha512-Tsio2tVcJgBa3WGhDty3Wy9XevTkZISrDsEpR8iaOnaPHdJrKXt7lbFrTEfptKjSgdnKcjhQXqzOdgiF9ljfnA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.21",
+        "@reown/appkit-controllers": "1.8.21",
+        "@reown/appkit-ui": "1.8.21",
+        "@reown/appkit-utils": "1.8.21",
+        "lit": "3.3.0",
+        "valtio": "2.1.7"
+      }
+    },
+    "node_modules/@reown/appkit-polyfills": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.21.tgz",
+      "integrity": "sha512-EurjE4G6M27yf77GPSuOu1gjUvpRKS3NC5FJgFMzZxmkF5/Dm9kQdokvzK1rdmtQ8JKe+XHmQ75NbmCFt1/7FQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "buffer": "6.0.3"
+      }
+    },
+    "node_modules/@reown/appkit-scaffold-ui": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.8.21.tgz",
+      "integrity": "sha512-bJxHdZmjwwAd1fIQmMgr0jjvyT1EI0KetFP+7UlTs51SxOflXzZ+rz9ZcWKNSLFtSQOro1+Xu6aPRO+5OapmhA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.21",
+        "@reown/appkit-controllers": "1.8.21",
+        "@reown/appkit-pay": "1.8.21",
+        "@reown/appkit-ui": "1.8.21",
+        "@reown/appkit-utils": "1.8.21",
+        "@reown/appkit-wallet": "1.8.21",
+        "lit": "3.3.0"
+      }
+    },
+    "node_modules/@reown/appkit-ui": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.21.tgz",
+      "integrity": "sha512-1AthTwGq1/gR1Xjib1kkt7unz0Hgh7wbdm1LvOA+Tfp79W8gM1BI/ELP/D8VwTOtaTgHCWERmlnps65p8MHi5Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@phosphor-icons/webcomponents": "2.1.5",
+        "@reown/appkit-common": "1.8.21",
+        "@reown/appkit-controllers": "1.8.21",
+        "@reown/appkit-wallet": "1.8.21",
+        "lit": "3.3.0",
+        "qrcode": "1.5.3"
+      }
+    },
+    "node_modules/@reown/appkit-utils": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.21.tgz",
+      "integrity": "sha512-WzEYji9oQIh9P8WkqXiqrLyx/ZYy+svpwT4u2ZC8n7sMSl0j+AzRqMaVrblyFEYAFkW/BtxVqJEqstDZ8f0FYw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.21",
+        "@reown/appkit-controllers": "1.8.21",
+        "@reown/appkit-polyfills": "1.8.21",
+        "@reown/appkit-wallet": "1.8.21",
+        "@wallet-standard/wallet": "1.1.0",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/universal-provider": "2.23.7",
+        "valtio": "2.1.7",
+        "viem": ">=2.45.0"
+      },
+      "optionalDependencies": {
+        "@base-org/account": "2.4.0",
+        "@coinbase/wallet-sdk": "4.3.6",
+        "@safe-global/safe-apps-provider": "0.18.6",
+        "@safe-global/safe-apps-sdk": "9.1.0"
+      },
+      "peerDependencies": {
+        "valtio": "2.1.7"
+      }
+    },
+    "node_modules/@reown/appkit-wallet": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.21.tgz",
+      "integrity": "sha512-4Y0W8QUdnXpy/KA9Lg1ESZN6VQurBIX3BhLQYIGwQ2/D3CuFe3xCbQDQOuDdgeAr0cMjgnFOvpGy0iOBH9Aivg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.21",
+        "@reown/appkit-polyfills": "1.8.21",
+        "@walletconnect/logger": "3.0.2",
+        "zod": "3.22.4"
+      }
+    },
+    "node_modules/@reown/appkit-wallet/node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1116,11 +2420,1263 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@safe-global/safe-apps-provider": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-provider/-/safe-apps-provider-0.18.6.tgz",
+      "integrity": "sha512-4LhMmjPWlIO8TTDC2AwLk44XKXaK6hfBTWyljDm0HQ6TWlOEijVWNrt2s3OCVMSxlXAcEzYfqyu1daHZooTC2Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@safe-global/safe-apps-sdk": "^9.1.0",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@safe-global/safe-apps-sdk": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-9.1.0.tgz",
+      "integrity": "sha512-N5p/ulfnnA2Pi2M3YeWjULeWbjo7ei22JwU/IXnhoHzKq3pYCN6ynL9mJBOlvDVv892EgLPCWCOwQk/uBT2v0Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@safe-global/safe-gateway-typescript-sdk": "^3.5.3",
+        "viem": "^2.1.1"
+      }
+    },
+    "node_modules/@safe-global/safe-gateway-typescript-sdk": {
+      "version": "3.23.1",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.23.1.tgz",
+      "integrity": "sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.33.24",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.33.24.tgz",
+      "integrity": "sha512-91up4t0BLjfkCZ4Ap/BcgaPrMaX6n0I2YRu+kc03xGhLy9G3N05nbTpnK8q7GXdv0PxwUoxi67A8o3Wr5U7j3w==",
+      "license": "MIT"
+    },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
+    },
+    "node_modules/@solana-program/system": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.10.0.tgz",
+      "integrity": "sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peerDependencies": {
+        "@solana/kit": "^5.0"
+      }
+    },
+    "node_modules/@solana-program/token": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.9.0.tgz",
+      "integrity": "sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peerDependencies": {
+        "@solana/kit": "^5.0"
+      }
+    },
+    "node_modules/@solana/accounts": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-5.5.1.tgz",
+      "integrity": "sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/addresses": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-5.5.1.tgz",
+      "integrity": "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/assertions": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/assertions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-5.5.1.tgz",
+      "integrity": "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/buffer-layout": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
+      "integrity": "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "~6.0.3"
+      },
+      "engines": {
+        "node": ">=5.10"
+      }
+    },
+    "node_modules/@solana/codecs": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-5.5.1.tgz",
+      "integrity": "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/options": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-core": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-5.5.1.tgz",
+      "integrity": "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-data-structures": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-5.5.1.tgz",
+      "integrity": "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-numbers": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-5.5.1.tgz",
+      "integrity": "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-strings": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-5.5.1.tgz",
+      "integrity": "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/errors": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-5.5.1.tgz",
+      "integrity": "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.2"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/errors/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/fast-stable-stringify": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-5.5.1.tgz",
+      "integrity": "sha512-Ni7s2FN33zTzhTFgRjEbOVFO+UAmK8qi3Iu0/GRFYK4jN696OjKHnboSQH/EacQ+yGqS54bfxf409wU5dsLLCw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/functional": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-5.5.1.tgz",
+      "integrity": "sha512-tTHoJcEQq3gQx5qsdsDJ0LEJeFzwNpXD80xApW9o/PPoCNimI3SALkZl+zNW8VnxRrV3l3yYvfHWBKe/X3WG3w==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-5.5.1.tgz",
+      "integrity": "sha512-7z3CB7YMcFKuVvgcnNY8bY6IsZ8LG61Iytbz7HpNVGX2u1RthOs1tRW8luTzSG1MPL0Ox7afyAVMYeFqSPHnaQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instructions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-5.5.1.tgz",
+      "integrity": "sha512-h0G1CG6S+gUUSt0eo6rOtsaXRBwCq1+Js2a+Ps9Bzk9q7YHNFA75/X0NWugWLgC92waRp66hrjMTiYYnLBoWOQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/keys": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-5.5.1.tgz",
+      "integrity": "sha512-KRD61cL7CRL+b4r/eB9dEoVxIf/2EJ1Pm1DmRYhtSUAJD2dJ5Xw8QFuehobOGm9URqQ7gaQl+Fkc1qvDlsWqKg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/assertions": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/nominal-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-5.5.1.tgz",
+      "integrity": "sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-5.5.1.tgz",
+      "integrity": "sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-5.5.1.tgz",
+      "integrity": "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-core": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-5.5.1.tgz",
+      "integrity": "sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-5.5.1.tgz",
+      "integrity": "sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/promises": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-5.5.1.tgz",
+      "integrity": "sha512-T9lfuUYkGykJmppEcssNiCf6yiYQxJkhiLPP+pyAc2z84/7r3UVIb2tNJk4A9sucS66pzJnVHZKcZVGUUp6wzA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-5.5.1.tgz",
+      "integrity": "sha512-ku8zTUMrkCWci66PRIBC+1mXepEnZH/q1f3ck0kJZ95a06bOTl5KU7HeXWtskkyefzARJ5zvCs54AD5nxjQJ+A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/fast-stable-stringify": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/rpc-api": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-transport-http": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-5.5.1.tgz",
+      "integrity": "sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/rpc-parsed-types": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-parsed-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-5.5.1.tgz",
+      "integrity": "sha512-HEi3G2nZqGEsa3vX6U0FrXLaqnUCg4SKIUrOe8CezD+cSFbRTOn3rCLrUmJrhVyXlHoQVaRO9mmeovk31jWxJg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-5.5.1.tgz",
+      "integrity": "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-5.5.1.tgz",
+      "integrity": "sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-5.5.1.tgz",
+      "integrity": "sha512-CTMy5bt/6mDh4tc6vUJms9EcuZj3xvK0/xq8IQ90rhkpYvate91RjBP+egvjgSayUg9yucU9vNuUpEjz4spM7w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/fast-stable-stringify": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-subscriptions-api": "5.5.1",
+        "@solana/rpc-subscriptions-channel-websocket": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/subscribable": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-5.5.1.tgz",
+      "integrity": "sha512-5Oi7k+GdeS8xR2ly1iuSFkAv6CZqwG0Z6b1QZKbEgxadE1XGSDrhM2cn59l+bqCozUWCqh4c/A2znU/qQjROlw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-5.5.1.tgz",
+      "integrity": "sha512-7tGfBBrYY8TrngOyxSHoCU5shy86iA9SRMRrPSyBhEaZRAk6dnbdpmUTez7gtdVo0BCvh9nzQtUycKWSS7PnFQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/subscribable": "5.5.1",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket/node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-5.5.1.tgz",
+      "integrity": "sha512-iq+rGq5fMKP3/mKHPNB6MC8IbVW41KGZg83Us/+LE3AWOTWV1WT20KT2iH1F1ik9roi42COv/TpoZZvhKj45XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/subscribable": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-5.5.1.tgz",
+      "integrity": "sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-5.5.1.tgz",
+      "integrity": "sha512-yv8GoVSHqEV0kUJEIhkdOVkR2SvJ6yoWC51cJn2rSV7plr6huLGe0JgujCmB7uZhhaLbcbP3zxXxu9sOjsi7Fg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "undici-types": "^7.19.2"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http/node_modules/undici-types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.29.0.tgz",
+      "integrity": "sha512-vamA8dGlzMwhpyYpQp9d8vka3o4D/yn5I7ez7Or+msDA4bZ8Uh+Zy91WvWf3I73gDAkFha9JcYRqm2li0Npfgg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@solana/rpc-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-5.5.1.tgz",
+      "integrity": "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-5.5.1.tgz",
+      "integrity": "sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/offchain-messages": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/subscribable": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-5.5.1.tgz",
+      "integrity": "sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-5.5.1.tgz",
+      "integrity": "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/accounts": "5.5.1",
+        "@solana/codecs": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-5.5.1.tgz",
+      "integrity": "sha512-j4mKlYPHEyu+OD7MBt3jRoX4ScFgkhZC6H65on4Fux6LMScgivPJlwnKoZMnsgxFgWds0pl+BYzSiALDsXlYtw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc": "5.5.1",
+        "@solana/rpc-subscriptions": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-5.5.1.tgz",
+      "integrity": "sha512-aXyhMCEaAp3M/4fP0akwBBQkFPr4pfwoC5CLDq999r/FUwDax2RE/h4Ic7h2Xk+JdcUwsb+rLq85Y52hq84XvQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-5.5.1.tgz",
+      "integrity": "sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/wallet-adapter-base": {
+      "version": "0.9.27",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-base/-/wallet-adapter-base-0.9.27.tgz",
+      "integrity": "sha512-kXjeNfNFVs/NE9GPmysBRKQ/nf+foSaq3kfVSeMcO/iVgigyRmB551OjU3WyAolLG/1jeEfKLqF9fKwMCRkUqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/wallet-standard-features": "^1.3.0",
+        "@wallet-standard/base": "^1.1.0",
+        "@wallet-standard/features": "^1.1.0",
+        "eventemitter3": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.98.0"
+      }
+    },
+    "node_modules/@solana/wallet-standard-features": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-features/-/wallet-standard-features-1.4.0.tgz",
+      "integrity": "sha512-f0tAdqwM2aL6CiFbIgt9h5zKFp+mgY/iNGwoxPMTj9VSTeQj7d1GGSmWhZw0XWoZ4N/1tnKTKmYFq+Dyq08jRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.0",
+        "@wallet-standard/features": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@solana/web3.js": {
+      "version": "1.98.4",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz",
+      "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "@noble/curves": "^1.4.2",
+        "@noble/hashes": "^1.4.0",
+        "@solana/buffer-layout": "^4.0.1",
+        "@solana/codecs-numbers": "^2.1.0",
+        "agentkeepalive": "^4.5.0",
+        "bn.js": "^5.2.1",
+        "borsh": "^0.7.0",
+        "bs58": "^4.0.1",
+        "buffer": "6.0.3",
+        "fast-stable-stringify": "^1.0.0",
+        "jayson": "^4.1.1",
+        "node-fetch": "^2.7.0",
+        "rpc-websockets": "^9.0.2",
+        "superstruct": "^2.0.2"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/@solana/codecs-core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/@solana/codecs-numbers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/@solana/errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/borsh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.2.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -1133,6 +3689,86 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@stellar/freighter-api": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-6.0.0.tgz",
+      "integrity": "sha512-8CTQcKQmTq/wL715ZUzn1x1POpR0eYhYPKEiaeA7AT0WYBOauOGTxfWPFtSidX3ohAlJZP5HFXy1kG29cVjqxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "6.0.3",
+        "semver": "7.7.1"
+      }
+    },
+    "node_modules/@stellar/freighter-api/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stellar/js-xdr": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
+      "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@stellar/stellar-base": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-13.1.0.tgz",
+      "integrity": "sha512-90EArG+eCCEzDGj3OJNoCtwpWDwxjv+rs/RNPhvg4bulpjN/CSRj+Ys/SalRcfM4/WRC5/qAfjzmJBAuquWhkA==",
+      "deprecated": "This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stellar/js-xdr": "^3.1.2",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^9.1.2",
+        "buffer": "^6.0.3",
+        "sha.js": "^2.3.6",
+        "tweetnacl": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "sodium-native": "^4.3.3"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-13.3.0.tgz",
+      "integrity": "sha512-8+GHcZLp+mdin8gSjcgfb/Lb6sSMYRX6Nf/0LcSJxvjLQR0XHpjGzOiRbYb2jSXo51EnA6kAV5j+4Pzh5OUKUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stellar/stellar-base": "^13.1.0",
+        "axios": "^1.8.4",
+        "bignumber.js": "^9.3.0",
+        "eventsource": "^2.0.2",
+        "feaxios": "^0.0.23",
+        "randombytes": "^2.1.0",
+        "toml": "^3.0.0",
+        "urijs": "^1.19.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk/node_modules/axios": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -1499,6 +4135,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.19.tgz",
       "integrity": "sha512-qTZRZ4QyTzQc+M0IzrbKHxSeISUmRB3RPGmao5bT+sI6ayxSRhn0FXEnT5Hg3as8SBFcRosrXXRFB+yAcxVxJQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.19"
       },
@@ -1560,6 +4197,2250 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@trezor/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@trezor/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-evILW5XJEmfPlf0TY1duOLtGJ47pdGeSKVE3P75ODEUsRNxtPVqlkOUBPmYpCxPnzS8XDmkatT8lf9/DF0G6nA==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@trezor/env-utils": "1.5.0",
+        "@trezor/utils": "9.5.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/analytics/node_modules/@trezor/env-utils": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@trezor/env-utils/-/env-utils-1.5.0.tgz",
+      "integrity": "sha512-u1TN7dMQ5Qhpbae08Z4JJmI9fQrbbJ4yj8eIAsuzMQn6vb+Sg9vbntl+IDsZ1G9WeI73uHTLu1wWMmAgiujH8w==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "ua-parser-js": "^2.0.4"
+      },
+      "peerDependencies": {
+        "expo-constants": "*",
+        "expo-localization": "*",
+        "react-native": "*",
+        "tslib": "^2.6.2"
+      },
+      "peerDependenciesMeta": {
+        "expo-constants": {
+          "optional": true
+        },
+        "expo-localization": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trezor/blockchain-link": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link/-/blockchain-link-2.6.2.tgz",
+      "integrity": "sha512-HMz+Dm6nMflqRkaebMqpv3uNnVkRrb6lD2HKTHNBGhjVbqf0wRzJ8JoQ08wn/sF00ljJZz8pGnpcMYHJNxE+wQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@solana-program/compute-budget": "^0.8.0",
+        "@solana-program/stake": "^0.2.1",
+        "@solana-program/token": "^0.5.1",
+        "@solana-program/token-2022": "^0.4.2",
+        "@solana/kit": "^2.3.0",
+        "@solana/rpc-types": "^2.3.0",
+        "@stellar/stellar-sdk": "14.2.0",
+        "@trezor/blockchain-link-types": "1.5.1",
+        "@trezor/blockchain-link-utils": "1.5.2",
+        "@trezor/env-utils": "1.5.0",
+        "@trezor/utils": "9.5.0",
+        "@trezor/utxo-lib": "2.5.0",
+        "@trezor/websocket-client": "1.3.0",
+        "@types/web": "^0.0.197",
+        "crypto-browserify": "3.12.0",
+        "socks-proxy-agent": "8.0.5",
+        "stream-browserify": "^3.0.0",
+        "xrpl": "4.4.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-types": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-types/-/blockchain-link-types-1.5.1.tgz",
+      "integrity": "sha512-Idavz6LwLBW8sXc69fh5AJEnl666EDl2Nt3io7updvBgOR0/P12I900DgjNhCKtiWuv66A33/5RE7zLcj3lfnw==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@trezor/utils": "9.5.0",
+        "@trezor/utxo-lib": "2.5.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-utils": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-utils/-/blockchain-link-utils-1.5.2.tgz",
+      "integrity": "sha512-OSS5OEE98FMnYfjoEALPjBt7ebjC/FKnq3HOolHdEWXBpVlXZNN2+Vo1R9J6WbZUU087sHuUTJJy/GJYWY13Tg==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@mobily/ts-belt": "^3.13.1",
+        "@stellar/stellar-sdk": "14.2.0",
+        "@trezor/env-utils": "1.5.0",
+        "@trezor/protobuf": "1.5.2",
+        "@trezor/utils": "9.5.0",
+        "xrpl": "4.4.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-utils/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-utils/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-utils/node_modules/@stellar/stellar-base": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-14.1.0.tgz",
+      "integrity": "sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw==",
+      "deprecated": "This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.9.6",
+        "@stellar/js-xdr": "^3.1.2",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^9.3.1",
+        "buffer": "^6.0.3",
+        "sha.js": "^2.4.12"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-utils/node_modules/@stellar/stellar-sdk": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-14.2.0.tgz",
+      "integrity": "sha512-7nh2ogzLRMhfkIC0fGjn1LHUzk3jqVw8tjAuTt5ADWfL9CSGBL18ILucE9igz2L/RU2AZgeAvhujAnW91Ut/oQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stellar/stellar-base": "^14.0.1",
+        "axios": "^1.12.2",
+        "bignumber.js": "^9.3.1",
+        "eventsource": "^2.0.2",
+        "feaxios": "^0.0.23",
+        "randombytes": "^2.1.0",
+        "toml": "^3.0.0",
+        "urijs": "^1.19.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-utils/node_modules/@trezor/env-utils": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@trezor/env-utils/-/env-utils-1.5.0.tgz",
+      "integrity": "sha512-u1TN7dMQ5Qhpbae08Z4JJmI9fQrbbJ4yj8eIAsuzMQn6vb+Sg9vbntl+IDsZ1G9WeI73uHTLu1wWMmAgiujH8w==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "ua-parser-js": "^2.0.4"
+      },
+      "peerDependencies": {
+        "expo-constants": "*",
+        "expo-localization": "*",
+        "react-native": "*",
+        "tslib": "^2.6.2"
+      },
+      "peerDependenciesMeta": {
+        "expo-constants": {
+          "optional": true
+        },
+        "expo-localization": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trezor/blockchain-link-utils/node_modules/@trezor/protobuf": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.5.2.tgz",
+      "integrity": "sha512-zViaL1jKue8DUTVEDg0C/lMipqNMd/Z3kr29/+MeZOoupjaXIQ2Lqp3WAMe8hvNTKKX8aNQH9JrbapJ6w9FMXw==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@trezor/schema-utils": "1.4.0",
+        "long": "5.2.5",
+        "protobufjs": "7.4.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-utils/node_modules/protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana-program/compute-budget": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/compute-budget/-/compute-budget-0.8.0.tgz",
+      "integrity": "sha512-qPKxdxaEsFxebZ4K5RPuy7VQIm/tfJLa1+Nlt3KNA8EYQkz9Xm8htdoEaXVrer9kpgzzp9R3I3Bh6omwCM06tQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana-program/stake": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/stake/-/stake-0.2.1.tgz",
+      "integrity": "sha512-ssNPsJv9XHaA+L7ihzmWGYcm/+XYURQ8UA3wQMKf6ccEHyHOUgoglkkDU/BoA0+wul6HxZUN0tHFymC0qFw6sg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana-program/token": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.5.1.tgz",
+      "integrity": "sha512-bJvynW5q9SFuVOZ5vqGVkmaPGA0MCC+m9jgJj1nk5m20I389/ms69ASnhWGoOPNcie7S9OwBX0gTj2fiyWpfag==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana-program/token-2022": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@solana-program/token-2022/-/token-2022-0.4.2.tgz",
+      "integrity": "sha512-zIpR5t4s9qEU3hZKupzIBxJ6nUV5/UVyIT400tu9vT1HMs5JHxaTTsb5GUhYjiiTvNwU0MQavbwc4Dl29L0Xvw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0",
+        "@solana/sysvars": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/accounts": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.3.0.tgz",
+      "integrity": "sha512-QgQTj404Z6PXNOyzaOpSzjgMOuGwG8vC66jSDB+3zHaRcEPRVRd2sVSrd1U6sHtnV3aiaS6YyDuPQMheg4K2jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/addresses": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.3.0.tgz",
+      "integrity": "sha512-ypTNkY2ZaRFpHLnHAgaW8a83N0/WoqdFvCqf4CQmnMdFsZSdC7qOwcbd7YzdaQn9dy+P2hybewzB+KP7LutxGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/assertions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.3.0.tgz",
+      "integrity": "sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.3.0.tgz",
+      "integrity": "sha512-JVqGPkzoeyU262hJGdH64kNLH0M+Oew2CIPOa/9tR3++q2pEd4jU2Rxdfye9sd0Ce3XJrR5AIa8ZfbyQXzjh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/options": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs-core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs-data-structures": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.3.0.tgz",
+      "integrity": "sha512-qvU5LE5DqEdYMYgELRHv+HMOx73sSoV1ZZkwIrclwUmwTbTaH8QAJURBj0RhQ/zCne7VuLLOZFFGv6jGigWhSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs-numbers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs-strings": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.3.0.tgz",
+      "integrity": "sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/fast-stable-stringify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.3.0.tgz",
+      "integrity": "sha512-KfJPrMEieUg6D3hfQACoPy0ukrAV8Kio883llt/8chPEG3FVTX9z/Zuf4O01a15xZmBbmQ7toil2Dp0sxMJSxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/functional": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.3.0.tgz",
+      "integrity": "sha512-AgsPh3W3tE+nK3eEw/W9qiSfTGwLYEvl0rWaxHht/lRcuDVwfKRzeSa5G79eioWFFqr+pTtoCr3D3OLkwKz02Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/instructions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.3.0.tgz",
+      "integrity": "sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/keys": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.3.0.tgz",
+      "integrity": "sha512-ZVVdga79pNH+2pVcm6fr2sWz9HTwfopDVhYb0Lh3dh+WBmJjwkabXEIHey2rUES7NjFa/G7sV8lrUn/v8LDCCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/kit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-2.3.0.tgz",
+      "integrity": "sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/accounts": "2.3.0",
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/programs": "2.3.0",
+        "@solana/rpc": "2.3.0",
+        "@solana/rpc-parsed-types": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-subscriptions": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/signers": "2.3.0",
+        "@solana/sysvars": "2.3.0",
+        "@solana/transaction-confirmation": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/nominal-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-2.3.0.tgz",
+      "integrity": "sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/options": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.3.0.tgz",
+      "integrity": "sha512-PPnnZBRCWWoZQ11exPxf//DRzN2C6AoFsDI/u2AsQfYih434/7Kp4XLpfOMT/XESi+gdBMFNNfbES5zg3wAIkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/programs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.3.0.tgz",
+      "integrity": "sha512-UXKujV71VCI5uPs+cFdwxybtHZAIZyQkqDiDnmK+DawtOO9mBn4Nimdb/6RjR2CXT78mzO9ZCZ3qfyX+ydcB7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/promises": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.3.0.tgz",
+      "integrity": "sha512-GjVgutZKXVuojd9rWy1PuLnfcRfqsaCm7InCiZc8bqmJpoghlyluweNc7ml9Y5yQn1P2IOyzh9+p/77vIyNybQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.3.0.tgz",
+      "integrity": "sha512-ZWN76iNQAOCpYC7yKfb3UNLIMZf603JckLKOOLTHuy9MZnTN8XV6uwvDFhf42XvhglgUjGCEnbUqWtxQ9pa/pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/fast-stable-stringify": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/rpc-api": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-transport-http": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-api": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.3.0.tgz",
+      "integrity": "sha512-UUdiRfWoyYhJL9PPvFeJr4aJ554ob2jXcpn4vKmRVn9ire0sCbpQKYx6K8eEKHZWXKrDW8IDspgTl0gT/aJWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/rpc-parsed-types": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-parsed-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.3.0.tgz",
+      "integrity": "sha512-B5pHzyEIbBJf9KHej+zdr5ZNAdSvu7WLU2lOUPh81KHdHQs6dEb310LGxcpCc7HVE8IEdO20AbckewDiAN6OCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-spec": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.3.0.tgz",
+      "integrity": "sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-spec-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.3.0.tgz",
+      "integrity": "sha512-xQsb65lahjr8Wc9dMtP7xa0ZmDS8dOE2ncYjlvfyw/h4mpdXTUdrSMi6RtFwX33/rGuztQ7Hwaid5xLNSLvsFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-subscriptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.3.0.tgz",
+      "integrity": "sha512-Uyr10nZKGVzvCOqwCZgwYrzuoDyUdwtgQRefh13pXIrdo4wYjVmoLykH49Omt6abwStB0a4UL5gX9V4mFdDJZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/fast-stable-stringify": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-subscriptions-api": "2.3.0",
+        "@solana/rpc-subscriptions-channel-websocket": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-subscriptions-api": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.3.0.tgz",
+      "integrity": "sha512-9mCjVbum2Hg9KGX3LKsrI5Xs0KX390lS+Z8qB80bxhar6MJPugqIPH8uRgLhCW9GN3JprAfjRNl7our8CPvsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-2.3.0.tgz",
+      "integrity": "sha512-2oL6ceFwejIgeWzbNiUHI2tZZnaOxNTSerszcin7wYQwijxtpVgUHiuItM/Y70DQmH9sKhmikQp+dqeGalaJxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.3.0.tgz",
+      "integrity": "sha512-rdmVcl4PvNKQeA2l8DorIeALCgJEMSu7U8AXJS1PICeb2lQuMeaR+6cs/iowjvIB0lMVjYN2sFf6Q3dJPu6wWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-transformers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.3.0.tgz",
+      "integrity": "sha512-UuHYK3XEpo9nMXdjyGKkPCOr7WsZsxs7zLYDO1A5ELH3P3JoehvrDegYRAGzBS2VKsfApZ86ZpJToP0K3PhmMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-transport-http": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.3.0.tgz",
+      "integrity": "sha512-HFKydmxGw8nAF5N+S0NLnPBDCe5oMDtI2RAmW8DMqP4U3Zxt2XWhvV1SNkAldT5tF0U1vP+is6fHxyhk4xqEvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "undici-types": "^7.11.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/rpc-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.3.0.tgz",
+      "integrity": "sha512-O09YX2hED2QUyGxrMOxQ9GzH1LlEwwZWu69QbL4oYmIf6P5dzEEHcqRY6L1LsDVqc/dzAdEs/E1FaPrcIaIIPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/signers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.3.0.tgz",
+      "integrity": "sha512-OSv6fGr/MFRx6J+ZChQMRqKNPGGmdjkqarKkRzkwmv7v8quWsIRnJT5EV8tBy3LI4DLO/A8vKiNSPzvm1TdaiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/subscribable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-2.3.0.tgz",
+      "integrity": "sha512-DkgohEDbMkdTWiKAoatY02Njr56WXx9e/dKKfmne8/Ad6/2llUIrax78nCdlvZW9quXMaXPTxZvdQqo9N669Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/sysvars": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.3.0.tgz",
+      "integrity": "sha512-LvjADZrpZ+CnhlHqfI5cmsRzX9Rpyb1Ox2dMHnbsRNzeKAMhu9w4ZBIaeTdO322zsTr509G1B+k2ABD3whvUBA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/accounts": "2.3.0",
+        "@solana/codecs": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/transaction-confirmation": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.3.0.tgz",
+      "integrity": "sha512-UiEuiHCfAAZEKdfne/XljFNJbsKAe701UQHKXEInYzIgBjRbvaeYZlBmkkqtxwcasgBTOmEaEKT44J14N9VZDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc": "2.3.0",
+        "@solana/rpc-subscriptions": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/transaction-messages": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.3.0.tgz",
+      "integrity": "sha512-bgqvWuy3MqKS5JdNLH649q+ngiyOu5rGS3DizSnWwYUd76RxZl1kN6CoqHSrrMzFMvis6sck/yPGG3wqrMlAww==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/transactions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.3.0.tgz",
+      "integrity": "sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@stellar/stellar-base": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-14.1.0.tgz",
+      "integrity": "sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw==",
+      "deprecated": "This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.9.6",
+        "@stellar/js-xdr": "^3.1.2",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^9.3.1",
+        "buffer": "^6.0.3",
+        "sha.js": "^2.4.12"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@stellar/stellar-sdk": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-14.2.0.tgz",
+      "integrity": "sha512-7nh2ogzLRMhfkIC0fGjn1LHUzk3jqVw8tjAuTt5ADWfL9CSGBL18ILucE9igz2L/RU2AZgeAvhujAnW91Ut/oQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stellar/stellar-base": "^14.0.1",
+        "axios": "^1.12.2",
+        "bignumber.js": "^9.3.1",
+        "eventsource": "^2.0.2",
+        "feaxios": "^0.0.23",
+        "randombytes": "^2.1.0",
+        "toml": "^3.0.0",
+        "urijs": "^1.19.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@trezor/env-utils": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@trezor/env-utils/-/env-utils-1.5.0.tgz",
+      "integrity": "sha512-u1TN7dMQ5Qhpbae08Z4JJmI9fQrbbJ4yj8eIAsuzMQn6vb+Sg9vbntl+IDsZ1G9WeI73uHTLu1wWMmAgiujH8w==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "ua-parser-js": "^2.0.4"
+      },
+      "peerDependencies": {
+        "expo-constants": "*",
+        "expo-localization": "*",
+        "react-native": "*",
+        "tslib": "^2.6.2"
+      },
+      "peerDependenciesMeta": {
+        "expo-constants": {
+          "optional": true
+        },
+        "expo-localization": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/undici-types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.29.0.tgz",
+      "integrity": "sha512-vamA8dGlzMwhpyYpQp9d8vka3o4D/yn5I7ez7Or+msDA4bZ8Uh+Zy91WvWf3I73gDAkFha9JcYRqm2li0Npfgg==",
+      "license": "MIT"
+    },
+    "node_modules/@trezor/connect": {
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/@trezor/connect/-/connect-9.7.3.tgz",
+      "integrity": "sha512-oAOfvJHT8tPqOXTmCOhn8uTZcoqSDuWAiWXQegx7C46tq+NLg+enkYXxUYEHq/9PmfZAOrUT9VMxZDsXM2thkA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ethereumjs/common": "^10.1.0",
+        "@ethereumjs/tx": "^10.1.0",
+        "@fivebinaries/coin-selection": "3.0.0",
+        "@mobily/ts-belt": "^3.13.1",
+        "@noble/hashes": "^1.6.1",
+        "@scure/bip39": "^1.5.1",
+        "@solana-program/compute-budget": "^0.8.0",
+        "@solana-program/system": "^0.7.0",
+        "@solana-program/token": "^0.5.1",
+        "@solana-program/token-2022": "^0.4.2",
+        "@solana/kit": "^2.3.0",
+        "@trezor/blockchain-link": "2.6.2",
+        "@trezor/blockchain-link-types": "1.5.1",
+        "@trezor/blockchain-link-utils": "1.5.2",
+        "@trezor/connect-analytics": "1.4.0",
+        "@trezor/connect-common": "0.5.1",
+        "@trezor/crypto-utils": "1.2.0",
+        "@trezor/device-authenticity": "1.1.2",
+        "@trezor/device-utils": "1.2.0",
+        "@trezor/env-utils": "^1.5.0",
+        "@trezor/protobuf": "1.5.3",
+        "@trezor/protocol": "1.3.1",
+        "@trezor/schema-utils": "1.4.0",
+        "@trezor/transport": "1.6.3",
+        "@trezor/type-utils": "1.2.0",
+        "@trezor/utils": "9.5.0",
+        "@trezor/utxo-lib": "2.5.0",
+        "blakejs": "^1.2.1",
+        "bs58": "^6.0.0",
+        "bs58check": "^4.0.0",
+        "cbor": "^10.0.10",
+        "cross-fetch": "^4.0.0",
+        "jws": "^4.0.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-analytics": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-analytics/-/connect-analytics-1.4.0.tgz",
+      "integrity": "sha512-hy2J2oeIhRC/e1bOWXo5dsVMVnDwO2UKnxhR6FD8PINR3jgM6PWAXc6k33WJsBcyiTzwMP7/xPysLcgNJH5o4w==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@trezor/analytics": "1.5.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-common": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-common/-/connect-common-0.5.1.tgz",
+      "integrity": "sha512-wdpVCwdylBh4SBO5Ys40tB/d59UlfjmxgBHDkkLgaR+JcqkthCfiw5VlUrV9wu65lquejAZhA5KQL4mUUUhCow==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@trezor/env-utils": "1.5.0",
+        "@trezor/type-utils": "1.2.0",
+        "@trezor/utils": "9.5.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-common/node_modules/@trezor/env-utils": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@trezor/env-utils/-/env-utils-1.5.0.tgz",
+      "integrity": "sha512-u1TN7dMQ5Qhpbae08Z4JJmI9fQrbbJ4yj8eIAsuzMQn6vb+Sg9vbntl+IDsZ1G9WeI73uHTLu1wWMmAgiujH8w==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "ua-parser-js": "^2.0.4"
+      },
+      "peerDependencies": {
+        "expo-constants": "*",
+        "expo-localization": "*",
+        "react-native": "*",
+        "tslib": "^2.6.2"
+      },
+      "peerDependenciesMeta": {
+        "expo-constants": {
+          "optional": true
+        },
+        "expo-localization": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trezor/connect-plugin-stellar": {
+      "version": "10.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-plugin-stellar/-/connect-plugin-stellar-10.0.0-alpha.1.tgz",
+      "integrity": "sha512-v4lMnnBPxLoV/Yf8F0WmtkZGNsqurpxK62kqvaDeVoAtn5Ud+l6POQkLeQRiGsJYVm0vSDc4LHb5vLMrZTH/KA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@trezor/utils": "10.0.0-alpha.1"
+      },
+      "peerDependencies": {
+        "@stellar/stellar-sdk": "^13.3.0",
+        "@trezor/connect": "9.x.x",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-plugin-stellar/node_modules/@trezor/utils": {
+      "version": "10.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-10.0.0-alpha.1.tgz",
+      "integrity": "sha512-A+txzREoeX2MO1AqocDBsMNe+R21jTx5kungXGuzeTRRevARLsYh8MPes0170uMjq4qNSgopBnYZK18WyksOmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.3.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-web": {
+      "version": "10.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-web/-/connect-web-10.0.0-alpha.1.tgz",
+      "integrity": "sha512-CW1ZXzXNVYrJ2WuYneLK2LznkRAfKxRPB3vJyv1U2gia5Q7hsblImITsutLOztO0C2xO1sfETTCyVzfRkRVJEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@trezor/connect-common": "10.0.0-alpha.1",
+        "@trezor/utils": "10.0.0-alpha.1",
+        "@trezor/websocket-client": "10.0.0-alpha.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "license": "MIT"
+    },
+    "node_modules/@trezor/connect-web/node_modules/@trezor/connect-common": {
+      "version": "10.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-common/-/connect-common-10.0.0-alpha.1.tgz",
+      "integrity": "sha512-tuvM72XHACogT/fkp9D8wyzTE8h4X9emYUhvFs2pdTyIfTFs5RHDbcHQWFsvJgJoTK0H44XSSJb8pORijRfn9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@trezor/device-utils": "10.0.0-alpha.1",
+        "@trezor/protobuf": "10.0.0-alpha.1",
+        "@trezor/protocol": "^10.0.0-alpha.1",
+        "@trezor/schema-utils": "10.0.0-alpha.1",
+        "@trezor/type-utils": "10.0.0-alpha.1",
+        "@trezor/utils": "10.0.0-alpha.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@trezor/device-utils": {
+      "version": "10.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@trezor/device-utils/-/device-utils-10.0.0-alpha.1.tgz",
+      "integrity": "sha512-93LhEqH8uKCZHLtF+62uxd3/PXCfqpK4Z98ztfGu5vrtmoONb9dV8Falha0b3KXPDrQ10TUKasFGKLg570Z/Ew==",
+      "license": "MIT"
+    },
+    "node_modules/@trezor/connect-web/node_modules/@trezor/protobuf": {
+      "version": "10.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-10.0.0-alpha.1.tgz",
+      "integrity": "sha512-aCUyqAr7Sho9TequaNAjnf27mgae6qzesNrOgB19bUrDrhaDDd/2eyr2SrrY1G4hPYkTyBC0jymvQnozn9f/kA==",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.11.0",
+        "@trezor/schema-utils": "10.0.0-alpha.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@trezor/protocol": {
+      "version": "10.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@trezor/protocol/-/protocol-10.0.0-beta.1.tgz",
+      "integrity": "sha512-kYcnIjSE1mnAkDDQz7roEDEIy3iBS2dkDPtOcd7lI37jpmvXj2Iu4P7jhG+n9SKb0bwu/e69EpmQOrjrwUX0Yw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@trezor/schema-utils": {
+      "version": "10.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@trezor/schema-utils/-/schema-utils-10.0.0-alpha.1.tgz",
+      "integrity": "sha512-0beYv0b0De3Z60sZzM1T+IrYwXeNL+7RKfLokTvqEFDzsQkwxhYrIX47FsBhGsOmGWx9x4+65dxDbnyd4wZT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.49",
+        "@trezor/type-utils": "10.0.0-alpha.1",
+        "ts-mixer": "^6.0.4"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@trezor/type-utils": {
+      "version": "10.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@trezor/type-utils/-/type-utils-10.0.0-alpha.1.tgz",
+      "integrity": "sha512-wK75rrwlyXFgPfdHQFRbeKCoj+orQLXKj7rliMK30z+F1y+rEcfv/MW2VP48Q9mL5pea+ZX1nRnb4hYx1v38Ow==",
+      "license": "MIT"
+    },
+    "node_modules/@trezor/connect-web/node_modules/@trezor/utils": {
+      "version": "10.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-10.0.0-alpha.1.tgz",
+      "integrity": "sha512-A+txzREoeX2MO1AqocDBsMNe+R21jTx5kungXGuzeTRRevARLsYh8MPes0170uMjq4qNSgopBnYZK18WyksOmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.3.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/@trezor/websocket-client": {
+      "version": "10.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@trezor/websocket-client/-/websocket-client-10.0.0-alpha.1.tgz",
+      "integrity": "sha512-129Ot1m+fDodRFBvav2d6v8nLxZLAl/udQP5l5W6jxQZcWUuviphDceT/juF8EvNGdw+L6OIu6fH+yCXARpFWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@trezor/utils": "10.0.0-alpha.1",
+        "ws": "^8.20.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/connect-web/node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana-program/compute-budget": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/compute-budget/-/compute-budget-0.8.0.tgz",
+      "integrity": "sha512-qPKxdxaEsFxebZ4K5RPuy7VQIm/tfJLa1+Nlt3KNA8EYQkz9Xm8htdoEaXVrer9kpgzzp9R3I3Bh6omwCM06tQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana-program/system": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.7.0.tgz",
+      "integrity": "sha512-FKTBsKHpvHHNc1ATRm7SlC5nF/VdJtOSjldhcyfMN9R7xo712Mo2jHIzvBgn8zQO5Kg0DcWuKB7268Kv1ocicw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana-program/token": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.5.1.tgz",
+      "integrity": "sha512-bJvynW5q9SFuVOZ5vqGVkmaPGA0MCC+m9jgJj1nk5m20I389/ms69ASnhWGoOPNcie7S9OwBX0gTj2fiyWpfag==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana-program/token-2022": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@solana-program/token-2022/-/token-2022-0.4.2.tgz",
+      "integrity": "sha512-zIpR5t4s9qEU3hZKupzIBxJ6nUV5/UVyIT400tu9vT1HMs5JHxaTTsb5GUhYjiiTvNwU0MQavbwc4Dl29L0Xvw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^2.1.0",
+        "@solana/sysvars": "^2.1.0"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/accounts": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.3.0.tgz",
+      "integrity": "sha512-QgQTj404Z6PXNOyzaOpSzjgMOuGwG8vC66jSDB+3zHaRcEPRVRd2sVSrd1U6sHtnV3aiaS6YyDuPQMheg4K2jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/addresses": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.3.0.tgz",
+      "integrity": "sha512-ypTNkY2ZaRFpHLnHAgaW8a83N0/WoqdFvCqf4CQmnMdFsZSdC7qOwcbd7YzdaQn9dy+P2hybewzB+KP7LutxGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/assertions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.3.0.tgz",
+      "integrity": "sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/codecs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.3.0.tgz",
+      "integrity": "sha512-JVqGPkzoeyU262hJGdH64kNLH0M+Oew2CIPOa/9tR3++q2pEd4jU2Rxdfye9sd0Ce3XJrR5AIa8ZfbyQXzjh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/options": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/codecs-core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/codecs-data-structures": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.3.0.tgz",
+      "integrity": "sha512-qvU5LE5DqEdYMYgELRHv+HMOx73sSoV1ZZkwIrclwUmwTbTaH8QAJURBj0RhQ/zCne7VuLLOZFFGv6jGigWhSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/codecs-numbers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/codecs-strings": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.3.0.tgz",
+      "integrity": "sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/fast-stable-stringify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.3.0.tgz",
+      "integrity": "sha512-KfJPrMEieUg6D3hfQACoPy0ukrAV8Kio883llt/8chPEG3FVTX9z/Zuf4O01a15xZmBbmQ7toil2Dp0sxMJSxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/functional": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.3.0.tgz",
+      "integrity": "sha512-AgsPh3W3tE+nK3eEw/W9qiSfTGwLYEvl0rWaxHht/lRcuDVwfKRzeSa5G79eioWFFqr+pTtoCr3D3OLkwKz02Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/instructions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.3.0.tgz",
+      "integrity": "sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/keys": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.3.0.tgz",
+      "integrity": "sha512-ZVVdga79pNH+2pVcm6fr2sWz9HTwfopDVhYb0Lh3dh+WBmJjwkabXEIHey2rUES7NjFa/G7sV8lrUn/v8LDCCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/kit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-2.3.0.tgz",
+      "integrity": "sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/accounts": "2.3.0",
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/programs": "2.3.0",
+        "@solana/rpc": "2.3.0",
+        "@solana/rpc-parsed-types": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-subscriptions": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/signers": "2.3.0",
+        "@solana/sysvars": "2.3.0",
+        "@solana/transaction-confirmation": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/nominal-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-2.3.0.tgz",
+      "integrity": "sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/options": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.3.0.tgz",
+      "integrity": "sha512-PPnnZBRCWWoZQ11exPxf//DRzN2C6AoFsDI/u2AsQfYih434/7Kp4XLpfOMT/XESi+gdBMFNNfbES5zg3wAIkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/programs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.3.0.tgz",
+      "integrity": "sha512-UXKujV71VCI5uPs+cFdwxybtHZAIZyQkqDiDnmK+DawtOO9mBn4Nimdb/6RjR2CXT78mzO9ZCZ3qfyX+ydcB7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/promises": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.3.0.tgz",
+      "integrity": "sha512-GjVgutZKXVuojd9rWy1PuLnfcRfqsaCm7InCiZc8bqmJpoghlyluweNc7ml9Y5yQn1P2IOyzh9+p/77vIyNybQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.3.0.tgz",
+      "integrity": "sha512-ZWN76iNQAOCpYC7yKfb3UNLIMZf603JckLKOOLTHuy9MZnTN8XV6uwvDFhf42XvhglgUjGCEnbUqWtxQ9pa/pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/fast-stable-stringify": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/rpc-api": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-transport-http": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-api": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.3.0.tgz",
+      "integrity": "sha512-UUdiRfWoyYhJL9PPvFeJr4aJ554ob2jXcpn4vKmRVn9ire0sCbpQKYx6K8eEKHZWXKrDW8IDspgTl0gT/aJWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/rpc-parsed-types": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-parsed-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.3.0.tgz",
+      "integrity": "sha512-B5pHzyEIbBJf9KHej+zdr5ZNAdSvu7WLU2lOUPh81KHdHQs6dEb310LGxcpCc7HVE8IEdO20AbckewDiAN6OCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-spec": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.3.0.tgz",
+      "integrity": "sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-spec-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.3.0.tgz",
+      "integrity": "sha512-xQsb65lahjr8Wc9dMtP7xa0ZmDS8dOE2ncYjlvfyw/h4mpdXTUdrSMi6RtFwX33/rGuztQ7Hwaid5xLNSLvsFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-subscriptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.3.0.tgz",
+      "integrity": "sha512-Uyr10nZKGVzvCOqwCZgwYrzuoDyUdwtgQRefh13pXIrdo4wYjVmoLykH49Omt6abwStB0a4UL5gX9V4mFdDJZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/fast-stable-stringify": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-subscriptions-api": "2.3.0",
+        "@solana/rpc-subscriptions-channel-websocket": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-subscriptions-api": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.3.0.tgz",
+      "integrity": "sha512-9mCjVbum2Hg9KGX3LKsrI5Xs0KX390lS+Z8qB80bxhar6MJPugqIPH8uRgLhCW9GN3JprAfjRNl7our8CPvsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/rpc-transformers": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-2.3.0.tgz",
+      "integrity": "sha512-2oL6ceFwejIgeWzbNiUHI2tZZnaOxNTSerszcin7wYQwijxtpVgUHiuItM/Y70DQmH9sKhmikQp+dqeGalaJxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/rpc-subscriptions-spec": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.3.0.tgz",
+      "integrity": "sha512-rdmVcl4PvNKQeA2l8DorIeALCgJEMSu7U8AXJS1PICeb2lQuMeaR+6cs/iowjvIB0lMVjYN2sFf6Q3dJPu6wWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/subscribable": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-transformers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.3.0.tgz",
+      "integrity": "sha512-UuHYK3XEpo9nMXdjyGKkPCOr7WsZsxs7zLYDO1A5ELH3P3JoehvrDegYRAGzBS2VKsfApZ86ZpJToP0K3PhmMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-transport-http": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.3.0.tgz",
+      "integrity": "sha512-HFKydmxGw8nAF5N+S0NLnPBDCe5oMDtI2RAmW8DMqP4U3Zxt2XWhvV1SNkAldT5tF0U1vP+is6fHxyhk4xqEvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-spec": "2.3.0",
+        "@solana/rpc-spec-types": "2.3.0",
+        "undici-types": "^7.11.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/rpc-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.3.0.tgz",
+      "integrity": "sha512-O09YX2hED2QUyGxrMOxQ9GzH1LlEwwZWu69QbL4oYmIf6P5dzEEHcqRY6L1LsDVqc/dzAdEs/E1FaPrcIaIIPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/nominal-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/signers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.3.0.tgz",
+      "integrity": "sha512-OSv6fGr/MFRx6J+ZChQMRqKNPGGmdjkqarKkRzkwmv7v8quWsIRnJT5EV8tBy3LI4DLO/A8vKiNSPzvm1TdaiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/subscribable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-2.3.0.tgz",
+      "integrity": "sha512-DkgohEDbMkdTWiKAoatY02Njr56WXx9e/dKKfmne8/Ad6/2llUIrax78nCdlvZW9quXMaXPTxZvdQqo9N669Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/sysvars": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.3.0.tgz",
+      "integrity": "sha512-LvjADZrpZ+CnhlHqfI5cmsRzX9Rpyb1Ox2dMHnbsRNzeKAMhu9w4ZBIaeTdO322zsTr509G1B+k2ABD3whvUBA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@solana/accounts": "2.3.0",
+        "@solana/codecs": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/transaction-confirmation": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.3.0.tgz",
+      "integrity": "sha512-UiEuiHCfAAZEKdfne/XljFNJbsKAe701UQHKXEInYzIgBjRbvaeYZlBmkkqtxwcasgBTOmEaEKT44J14N9VZDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/promises": "2.3.0",
+        "@solana/rpc": "2.3.0",
+        "@solana/rpc-subscriptions": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0",
+        "@solana/transactions": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/transaction-messages": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.3.0.tgz",
+      "integrity": "sha512-bgqvWuy3MqKS5JdNLH649q+ngiyOu5rGS3DizSnWwYUd76RxZl1kN6CoqHSrrMzFMvis6sck/yPGG3wqrMlAww==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@solana/transactions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.3.0.tgz",
+      "integrity": "sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "2.3.0",
+        "@solana/codecs-core": "2.3.0",
+        "@solana/codecs-data-structures": "2.3.0",
+        "@solana/codecs-numbers": "2.3.0",
+        "@solana/codecs-strings": "2.3.0",
+        "@solana/errors": "2.3.0",
+        "@solana/functional": "2.3.0",
+        "@solana/instructions": "2.3.0",
+        "@solana/keys": "2.3.0",
+        "@solana/nominal-types": "2.3.0",
+        "@solana/rpc-types": "2.3.0",
+        "@solana/transaction-messages": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/@trezor/env-utils": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@trezor/env-utils/-/env-utils-1.5.0.tgz",
+      "integrity": "sha512-u1TN7dMQ5Qhpbae08Z4JJmI9fQrbbJ4yj8eIAsuzMQn6vb+Sg9vbntl+IDsZ1G9WeI73uHTLu1wWMmAgiujH8w==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "ua-parser-js": "^2.0.4"
+      },
+      "peerDependencies": {
+        "expo-constants": "*",
+        "expo-localization": "*",
+        "react-native": "*",
+        "tslib": "^2.6.2"
+      },
+      "peerDependenciesMeta": {
+        "expo-constants": {
+          "optional": true
+        },
+        "expo-localization": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@trezor/connect/node_modules/undici-types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.29.0.tgz",
+      "integrity": "sha512-vamA8dGlzMwhpyYpQp9d8vka3o4D/yn5I7ez7Or+msDA4bZ8Uh+Zy91WvWf3I73gDAkFha9JcYRqm2li0Npfgg==",
+      "license": "MIT"
+    },
+    "node_modules/@trezor/crypto-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@trezor/crypto-utils/-/crypto-utils-1.2.0.tgz",
+      "integrity": "sha512-9i1NrfW1IE6JO910ut7xrx4u5LxE++GETbpJhWLj4P5xpuGDDSDLEn/MXaYisls2DpE897aOrGPaa1qyt8V6tw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/device-authenticity": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@trezor/device-authenticity/-/device-authenticity-1.1.2.tgz",
+      "integrity": "sha512-313uSXYR4XKDv3CjtCpgHA+yEe9xxqN7EFl/D68FEn70SPsuWI0+2zUvjPPh6TIOh/EcLv7hCO/QTHUAGd7ZWQ==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@noble/curves": "^2.0.1",
+        "@trezor/crypto-utils": "1.2.0",
+        "@trezor/protobuf": "1.5.2",
+        "@trezor/schema-utils": "1.4.0",
+        "@trezor/utils": "9.5.0"
+      }
+    },
+    "node_modules/@trezor/device-authenticity/node_modules/@noble/curves": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.3.0.tgz",
+      "integrity": "sha512-v7cY+4oWYPQszRj6ZFGzTVL7uP2TaLo1xMhWHzYC5wj0ZhOXQ5x+sBre8rF3hi8cAoi0bh1qXoovoOkdFtvqEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.3.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@trezor/device-authenticity/node_modules/@noble/hashes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
+      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@trezor/device-authenticity/node_modules/@trezor/protobuf": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.5.2.tgz",
+      "integrity": "sha512-zViaL1jKue8DUTVEDg0C/lMipqNMd/Z3kr29/+MeZOoupjaXIQ2Lqp3WAMe8hvNTKKX8aNQH9JrbapJ6w9FMXw==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@trezor/schema-utils": "1.4.0",
+        "long": "5.2.5",
+        "protobufjs": "7.4.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/device-authenticity/node_modules/protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@trezor/device-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@trezor/device-utils/-/device-utils-1.2.0.tgz",
+      "integrity": "sha512-Aqp7pIooFTx21zRUtTI6i1AS4d9Lrx7cclvksh2nJQF9WJvbzuCXshEGkLoOsHwhQrCl3IXfbGuMdA12yDenPA==",
+      "license": "See LICENSE.md in repo root"
+    },
+    "node_modules/@trezor/protobuf": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.5.3.tgz",
+      "integrity": "sha512-ZYQtapkT2NaiVrAgb91Zprnk3uhl2Wca0bsnJcWgE7vwzqKegjrSorRnkZLqLTKTbCaT6sgkCYtM2hPl4Hqw5Q==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@trezor/schema-utils": "1.4.0",
+        "long": "5.2.5",
+        "protobufjs": "7.5.5"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/protocol": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@trezor/protocol/-/protocol-1.3.1.tgz",
+      "integrity": "sha512-uNJ83n38+BM+AJKsWza1ocvQ206d6NXJQ8/g+DelPLTj5c37Rj6hFiY5Nb5zgM7DBnq6T8Aa2K8t4TVCzHT1qg==",
+      "license": "See LICENSE.md in repo root",
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/schema-utils": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@trezor/schema-utils/-/schema-utils-1.4.0.tgz",
+      "integrity": "sha512-K7upSeh7VDrORaIC4KAxYVW93XNlohmUnH5if/5GKYmTdQSRp1nBkO6Jm+Z4hzIthdnz/1aLgnbeN3bDxWLRxA==",
+      "license": "See LICENSE.md in repo root",
+      "dependencies": {
+        "@sinclair/typebox": "^0.33.7",
+        "ts-mixer": "^6.0.3"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/transport": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@trezor/transport/-/transport-1.6.3.tgz",
+      "integrity": "sha512-GEi9KfiJsBgT/MCGNDIn9RDeXceLaAPjJT/GCayirXaCr3KnlpZCs6LGYkrjqapxiBm73nxM+BctKBKhpUl2cQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@trezor/protobuf": "1.5.3",
+        "@trezor/protocol": "1.3.1",
+        "@trezor/type-utils": "1.2.0",
+        "@trezor/utils": "9.5.0",
+        "cross-fetch": "^4.0.0",
+        "usb": "^2.15.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/type-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@trezor/type-utils/-/type-utils-1.2.0.tgz",
+      "integrity": "sha512-+E2QntxkyQuYfQQyl8RvT01tq2i5Dp/LFUOXuizF+KVOqsZBjBY43j5hewcCO3+MokD7deDiPyekbUEN5/iVlw==",
+      "license": "See LICENSE.md in repo root"
+    },
+    "node_modules/@trezor/utils": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-9.5.0.tgz",
+      "integrity": "sha512-kdyMyDbxzvOZmwBNvTjAK+C/kzyOz8T4oUbFvq+KaXn5mBFf1uf8rq5X2HkxgdYRPArtHS3PxLKsfkNCdhCYtQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "bignumber.js": "^9.3.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/utxo-lib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@trezor/utxo-lib/-/utxo-lib-2.5.0.tgz",
+      "integrity": "sha512-Fa2cZh0037oX6AHNLfpFIj65UR/OoX0ZJTocFuQASe77/1PjZHysf6BvvGfmzuFToKfrAQ+DM/1Sx+P/vnyNmA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@trezor/utils": "9.5.0",
+        "bech32": "^2.0.0",
+        "bip66": "^2.0.0",
+        "bitcoin-ops": "^1.4.1",
+        "blake-hash": "^2.0.0",
+        "blakejs": "^1.2.1",
+        "bn.js": "^5.2.2",
+        "bs58": "^6.0.0",
+        "bs58check": "^4.0.0",
+        "cashaddrjs": "0.4.4",
+        "create-hmac": "^1.1.7",
+        "int64-buffer": "^1.1.0",
+        "pushdata-bitcoin": "^1.0.1",
+        "tiny-secp256k1": "^1.1.7",
+        "typeforce": "^1.18.0",
+        "varuint-bitcoin": "2.0.0",
+        "wif": "^5.0.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/websocket-client": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@trezor/websocket-client/-/websocket-client-1.3.0.tgz",
+      "integrity": "sha512-9KQSaVc3NtmM6rFFj1e+9bM0C5mVKVidbnxlfzuBJu7G2YMRdIdLPcAXhvmRZjs40uzDuBeApK+p547kODz2ug==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@trezor/utils": "9.5.0",
+        "ws": "^8.18.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1569,6 +6450,15 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/d3-array": {
@@ -1655,7 +6545,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -1669,7 +6558,6 @@
       "version": "20.19.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1681,6 +6569,7 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1699,7 +6588,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {
@@ -1707,6 +6595,33 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/w3c-web-usb": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.14.tgz",
+      "integrity": "sha512-Qu3Nn6JFuF4+sHKYl+IcX9vYiI40ogleXzFFSxoE1W94rG98o/kXs8uJ0QSfFzuwBCZWlGfUGpPkgwuuX4PchA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/web": {
+      "version": "0.0.197",
+      "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.197.tgz",
+      "integrity": "sha512-V4sOroWDADFx9dLodWpKm298NOJ1VJ6zoDVgaP+WBb/utWxqQ6gnMzd9lvVDAr/F3ibiKaxH9i45eS0gQPSTaQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.53.1",
@@ -1753,6 +6668,7 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -2305,12 +7221,919 @@
         }
       }
     },
+    "node_modules/@wallet-standard/base": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-gggIHTtxicF9XFMQ12DkfS6NAG92Ak795JeSA7f2whAQ6Y3AkMWWuCMxSZXG2NIPN42kEaZSNVjqMsJRaJRxMQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@wallet-standard/features": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.1.tgz",
+      "integrity": "sha512-aCWYmVeSCGViyEU5k7GMoW8zxE4Gs+C1s1Pp2XLesvSNlnZ4PMES9HUnTB3hl0b3RVj7C61yze3IWyrncqg4MA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@wallet-standard/wallet": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/wallet/-/wallet-1.1.0.tgz",
+      "integrity": "sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@walletconnect/core": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.0.tgz",
+      "integrity": "sha512-W++xuXf+AsMPrBWn1It8GheIbCTp1ynTQP+aoFB86eUwyCtSiK7UQsn/+vJZdwElrn+Ptp2A0RqQx2onTMVHjQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.0",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.0",
+        "@walletconnect/utils": "2.23.0",
+        "@walletconnect/window-getters": "1.0.1",
+        "es-toolkit": "1.39.3",
+        "events": "3.3.0",
+        "uint8arrays": "3.1.1"
+      },
+      "engines": {
+        "node": ">=18.20.8"
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/@walletconnect/keyvaluestorage": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
+      "integrity": "sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.1",
+        "idb-keyval": "^6.2.1",
+        "unstorage": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": "1.x"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/@walletconnect/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "10.0.0"
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/@walletconnect/types": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.0.tgz",
+      "integrity": "sha512-9ZEOJyx/kNVCRncDHh3Qr9eH7Ih1dXBFB4k1J8iEudkv3t4GhYpXhqIt2kNdQWluPb1BBB4wEuckAT96yKuA8g==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.0",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/es-toolkit": {
+      "version": "1.39.3",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.3.tgz",
+      "integrity": "sha512-Qb/TCFCldgOy8lZ5uC7nLGdqJwSabkQiYQShmw4jyiPk1pZzaYWTwaYKYP7EgLccWYgZocMrtItrwh683voaww==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
+    "node_modules/@walletconnect/environment": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/environment/-/environment-1.0.1.tgz",
+      "integrity": "sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/environment/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/events": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/events/-/events-1.0.1.tgz",
+      "integrity": "sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "keyvaluestorage-interface": "^1.0.0",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/events/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/heartbeat": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.2.tgz",
+      "integrity": "sha512-uASiRmC5MwhuRuf05vq4AT48Pq8RMi876zV8rr8cV969uTOzWdB/k+Lj5yI2PBtB1bGQisGen7MM1GcZlQTBXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/events": "^1.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-http-connection": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-http-connection/-/jsonrpc-http-connection-1.0.8.tgz",
+      "integrity": "sha512-+B7cRuaxijLeFDJUq5hAzNyef3e3tBDIxyaCNmFtjwnod5AGis3RToNqzFU33vpVcxFhofkpE7Cx+5MYejbMGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
+        "@walletconnect/safe-json": "^1.0.1",
+        "cross-fetch": "^3.1.4",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-http-connection/node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-provider": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.14.tgz",
+      "integrity": "sha512-rtsNY1XqHvWj0EtITNeuf8PHMvlCLiS3EjQL+WOkxEOA4KPxsohFnBDeyPYiNm4ZvkQdLnece36opYidmtbmow==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.8",
+        "@walletconnect/safe-json": "^1.0.2",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-types": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.4.tgz",
+      "integrity": "sha512-P6679fG/M+wuWg9TY8mh6xFSdYnFyFjwFelxyISxMDrlbXokorEVXYOxiqEbrU3x1BmBoCAJJ+vtEaEoMlpCBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.3.0",
+        "keyvaluestorage-interface": "^1.0.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-utils": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz",
+      "integrity": "sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/environment": "^1.0.1",
+        "@walletconnect/jsonrpc-types": "^1.0.3",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-utils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/jsonrpc-ws-connection": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.16.tgz",
+      "integrity": "sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
+        "@walletconnect/safe-json": "^1.0.2",
+        "events": "^3.3.0",
+        "ws": "^7.5.1"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/logger": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.2.tgz",
+      "integrity": "sha512-7wR3wAwJTOmX4gbcUZcFMov8fjftY05+5cO/d4cpDD8wDzJ+cIlKdYOXaXfxHLSYeDazMXIsxMYjHYVDfkx+nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "10.0.0"
+      }
+    },
+    "node_modules/@walletconnect/relay-api": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.11.tgz",
+      "integrity": "sha512-tLPErkze/HmC9aCmdZOhtVmYZq1wKfWTJtygQHoWtgg722Jd4homo54Cs4ak2RUFUZIGO2RsOpIcWipaua5D5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/jsonrpc-types": "^1.0.2"
+      }
+    },
+    "node_modules/@walletconnect/relay-auth": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-auth/-/relay-auth-1.1.0.tgz",
+      "integrity": "sha512-qFw+a9uRz26jRCDgL7Q5TA9qYIgcNY8jpJzI1zAWNZ8i7mQjaijRnWFKsCHAU9CyGjvt6RKrRXyFtFOpWTVmCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.8.0",
+        "@noble/hashes": "1.7.0",
+        "@walletconnect/safe-json": "^1.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "node_modules/@walletconnect/relay-auth/node_modules/@noble/curves": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.0.tgz",
+      "integrity": "sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.7.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/relay-auth/node_modules/@noble/hashes": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz",
+      "integrity": "sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/safe-json": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/safe-json/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/sign-client": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.0.tgz",
+      "integrity": "sha512-Nzf5x/LnQgC0Yjk0NmkT8kdrIMcScpALiFm9gP0n3CulL+dkf3HumqWzdoTmQSqGPxwHu/TNhGOaRKZLGQXSqw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/core": "2.23.0",
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/logger": "3.0.0",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.0",
+        "@walletconnect/utils": "2.23.0",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/sign-client/node_modules/@walletconnect/keyvaluestorage": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
+      "integrity": "sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.1",
+        "idb-keyval": "^6.2.1",
+        "unstorage": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": "1.x"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/sign-client/node_modules/@walletconnect/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "10.0.0"
+      }
+    },
+    "node_modules/@walletconnect/sign-client/node_modules/@walletconnect/types": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.0.tgz",
+      "integrity": "sha512-9ZEOJyx/kNVCRncDHh3Qr9eH7Ih1dXBFB4k1J8iEudkv3t4GhYpXhqIt2kNdQWluPb1BBB4wEuckAT96yKuA8g==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.0",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/time/-/time-1.0.2.tgz",
+      "integrity": "sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/time/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/types": {
+      "version": "2.23.9",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.9.tgz",
+      "integrity": "sha512-IUl1PpD/Dig8IE2OZ9XtjbPohEyOZJ73xs92EDUzoIyzRtfm36g2D340pY3iu3AAdLv1yFiaZafB8Hf8RFze8A==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/types/node_modules/@walletconnect/keyvaluestorage": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
+      "integrity": "sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.1",
+        "idb-keyval": "^6.2.1",
+        "unstorage": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": "1.x"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/universal-provider": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.23.7.tgz",
+      "integrity": "sha512-6UicU/Mhr/1bh7MNoajypz7BhigORbHpP1LFTf8FYLQGDqzmqHMqmMH2GDAImtaY2sFTi2jBvc22tLl8VMze/A==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/jsonrpc-http-connection": "1.0.8",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/sign-client": "2.23.7",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
+        "es-toolkit": "1.44.0",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/@msgpack/msgpack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/core": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.7.tgz",
+      "integrity": "sha512-yTyymn9mFaDZkUfLfZ3E9VyaSDPeHAXlrPxQRmNx2zFsEt/25GmTU2A848aomimLxZnAG2jNLhxbJ8I0gyNV+w==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
+        "@walletconnect/window-getters": "1.0.1",
+        "es-toolkit": "1.44.0",
+        "events": "3.3.0",
+        "uint8arrays": "3.1.1"
+      },
+      "engines": {
+        "node": ">=18.20.8"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/keyvaluestorage": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
+      "integrity": "sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.1",
+        "idb-keyval": "^6.2.1",
+        "unstorage": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": "1.x"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/sign-client": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.7.tgz",
+      "integrity": "sha512-SX61lzb1bTl/LijlcHQttnoHPBzzoY5mW9ArR6qhFtDNDTS7yr2rcH7rCngxHlYeb4rAYcWLHgbiGSrdKxl/mg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/core": "2.23.7",
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/types": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.7.tgz",
+      "integrity": "sha512-6PAKK+iR2IntmlkCFLMAHjYeIaerCJJYRDmdRimhon0u+aNmQT+HyGM6zxDAth0rdpBD7qEvKP5IXZTE7KFUhw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/utils": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.7.tgz",
+      "integrity": "sha512-3p38gNrkVcIiQixVrlsWSa66Gjs5PqHOug2TxDgYUVBW5NcKjwQA08GkC6CKBQUfr5iaCtbfy6uZJW1LKSIvWQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@msgpack/msgpack": "3.1.3",
+        "@noble/ciphers": "1.3.0",
+        "@noble/curves": "1.9.7",
+        "@noble/hashes": "1.8.0",
+        "@scure/base": "1.2.6",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/window-getters": "1.0.1",
+        "@walletconnect/window-metadata": "1.0.1",
+        "blakejs": "1.2.1",
+        "detect-browser": "5.3.0",
+        "ox": "0.9.3",
+        "uint8arrays": "3.1.1"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/ox": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.3.tgz",
+      "integrity": "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.0.9",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/universal-provider/node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/utils": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.0.tgz",
+      "integrity": "sha512-bVyv4Hl+/wVGueZ6rEO0eYgDy5deSBA4JjpJHAMOdaNoYs05NTE1HymV2lfPQQHuqc7suYexo9jwuW7i3JLuAA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@msgpack/msgpack": "3.1.2",
+        "@noble/ciphers": "1.3.0",
+        "@noble/curves": "1.9.7",
+        "@noble/hashes": "1.8.0",
+        "@scure/base": "1.2.6",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.0",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.0",
+        "@walletconnect/window-getters": "1.0.1",
+        "@walletconnect/window-metadata": "1.0.1",
+        "blakejs": "1.2.1",
+        "bs58": "6.0.0",
+        "detect-browser": "5.3.0",
+        "ox": "0.9.3",
+        "uint8arrays": "3.1.1"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@walletconnect/keyvaluestorage": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
+      "integrity": "sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.1",
+        "idb-keyval": "^6.2.1",
+        "unstorage": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": "1.x"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@walletconnect/logger": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.0.tgz",
+      "integrity": "sha512-DDktPBFdmt5d7U3sbp4e3fQHNS1b6amsR8FmtOnt6L2SnV7VfcZr8VmAGL12zetAR+4fndegbREmX0P8Mw6eDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "10.0.0"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@walletconnect/types": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.0.tgz",
+      "integrity": "sha512-9ZEOJyx/kNVCRncDHh3Qr9eH7Ih1dXBFB4k1J8iEudkv3t4GhYpXhqIt2kNdQWluPb1BBB4wEuckAT96yKuA8g==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.0",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/@walletconnect/utils/node_modules/ox": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.3.tgz",
+      "integrity": "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.0.9",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/window-getters": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
+      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/window-getters/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/window-metadata": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
+      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/window-getters": "^1.0.1",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/window-metadata/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@xrplf/isomorphic": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@xrplf/isomorphic/-/isomorphic-1.0.2.tgz",
+      "integrity": "sha512-ncZUdMXr6VlSXtdoiDi0jTH+gBrgGxwVeEidhoegII3PmyErbQsyj6e+j7acmR4LW/lvBkPkzb9QzRfJH0n3rA==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1",
+        "eventemitter3": "5.0.1",
+        "ws": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@xrplf/isomorphic/node_modules/@noble/hashes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
+      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@xrplf/isomorphic/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/@xrplf/isomorphic/node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xrplf/secret-numbers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@xrplf/secret-numbers/-/secret-numbers-2.0.0.tgz",
+      "integrity": "sha512-z3AOibRTE9E8MbjgzxqMpG1RNaBhQ1jnfhNCa1cGf2reZUJzPMYs4TggQTc7j8+0WyV3cr7y/U8Oz99SXIkN5Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@xrplf/isomorphic": "^1.0.1",
+        "ripple-keypairs": "^2.0.0"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.3.0.tgz",
+      "integrity": "sha512-fk6Te+bojIFrMvMZrnOO+SxCB+RUksTGOzq/60ZRvs1L+BVzvi2bqt9L3W/17ZLdZsyM1FuYf65P5nlmoiH1Bg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2326,6 +8149,27 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -2345,11 +8189,19 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2359,6 +8211,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/argparse": {
@@ -2538,6 +8403,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -2555,11 +8437,25 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -2581,6 +8477,31 @@
         "node": ">=4"
       }
     },
+    "node_modules/axios": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
+      "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "is-retry-allowed": "^2.2.0"
+      },
+      "peerDependencies": {
+        "axios": "0.x || 1.x"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -2597,6 +8518,182 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bare-addon-resolve": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.1.tgz",
+      "integrity": "sha512-F/SD2du8keuYSb4xipnGz5j2E6yhNdHA8ZVxtHae6h2uOrpBIjjbhXvjzKZbr5XUOzqBzh/i8GVFycj2DlFQIA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-module-resolve": "^1.10.0",
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-module-resolve": {
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.4.tgz",
+      "integrity": "sha512-xcfgg2u7HqgJiBmah71O9vvdFAgHCvkqC/WSC2O7Bbgosoc1eC/BWe/6IDJ4OsfKlkxuvC/TDWXC+oH5yeW8mA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-semver": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.1.0.tgz",
+      "integrity": "sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
+    },
+    "node_modules/base32.js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
+      "integrity": "sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+      "license": "MIT"
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.36",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
+      "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/big.js": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.2.tgz",
+      "integrity": "sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bip32-path": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/bip32-path/-/bip32-path-0.4.2.tgz",
+      "integrity": "sha512-ZBMCELjJfcNMkz5bDuJ1WrYvjlhEF5k6mQ8vUr4N7MbVRsXei7ZOg8VhhwMfNiW68NWmLkgkc6WvTickrLGprQ==",
+      "license": "MIT"
+    },
+    "node_modules/bip66": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-2.0.0.tgz",
+      "integrity": "sha512-kBG+hSpgvZBrkIm9dt5T1Hd/7xGCPEX2npoxAWZfsK1FvjgaxySEh2WizjyIstWXriKo9K9uJ4u0OnsyLDUPXQ==",
+      "license": "MIT"
+    },
+    "node_modules/bitcoin-ops": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
+      "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow==",
+      "license": "MIT"
+    },
+    "node_modules/blake-hash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/blake-hash/-/blake-hash-2.0.0.tgz",
+      "integrity": "sha512-Igj8YowDu1PRkRsxZA7NVkdFNxH5rKv5cpLxQ0CVXSIA77pVYwCPRQJ2sMew/oneUpfuYRyjG6r8SmmmnbZb1w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^3.0.0",
+        "node-gyp-build": "^4.2.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "license": "MIT"
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz",
+      "integrity": "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==",
+      "license": "MIT"
+    },
+    "node_modules/borsh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-2.0.0.tgz",
+      "integrity": "sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==",
+      "license": "Apache-2.0"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -2622,11 +8719,184 @@
         "node": ">=8"
       }
     },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "license": "MIT"
+    },
+    "node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "node_modules/browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/browserify-rsa": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+      "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^5.2.1",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserify-sign": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.6.tgz",
+      "integrity": "sha512-sd+Q65fjlWCYWtZKXiKfrUc8d+4jtp/8f0W2NkwzLtoW4bI6UDnWusLWIurHnmurW0XShIRxpwiOX4EoPtXUAg==",
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^5.2.3",
+        "browserify-rsa": "^4.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.6.1",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.9",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
+    },
+    "node_modules/bs58check": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "bs58": "^6.0.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "license": "MIT"
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -2645,7 +8915,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2659,7 +8928,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2677,6 +8945,15 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2702,6 +8979,27 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cashaddrjs": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/cashaddrjs/-/cashaddrjs-0.4.4.tgz",
+      "integrity": "sha512-xZkuWdNOh0uq/mxJIng6vYWfTowZLd9F4GMAlp2DwFHlcCqCm91NtuAc47RuV4L7r4PYcY5p6Cr2OKNb4hnkWA==",
+      "license": "MIT",
+      "dependencies": {
+        "big-integer": "1.6.36"
+      }
+    },
+    "node_modules/cbor": {
+      "version": "10.0.12",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-10.0.12.tgz",
+      "integrity": "sha512-exQDevYd7ZQLP4moMQcZkKCVZsXLAtUSflObr3xTh4xzFIv/xBCdvCd6L259kQOUP2kcTC0jvC6PpZIf/WmRXA==",
+      "license": "MIT",
+      "dependencies": {
+        "nofilter": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2719,11 +9017,60 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cipher-base": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -2738,7 +9085,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2751,8 +9097,28 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2760,6 +9126,70 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie-es": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/create-ecdh": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      }
+    },
+    "node_modules/create-ecdh/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2776,11 +9206,52 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crossws": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/crypto-browserify": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -2974,6 +9445,12 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2989,6 +9466,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js-light": {
@@ -3008,7 +9494,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -3040,6 +9525,84 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
+    },
+    "node_modules/delay": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "license": "MIT"
+    },
+    "node_modules/detect-browser": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==",
+      "license": "MIT"
+    },
+    "node_modules/detect-europe-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3048,6 +9611,29 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "node_modules/diffie-hellman/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -3075,7 +9661,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3086,11 +9671,42 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
+    },
     "node_modules/embla-carousel": {
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -3119,6 +9735,12 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encode-utf8": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
+      "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==",
       "license": "MIT"
     },
     "node_modules/engine.io-client": {
@@ -3230,7 +9852,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3240,7 +9861,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3278,7 +9898,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3291,7 +9910,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3344,6 +9962,21 @@
         "benchmarks"
       ]
     },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
+    },
+    "node_modules/es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^4.0.3"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -3363,6 +9996,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3536,6 +10170,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3788,6 +10423,57 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "license": "MIT",
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
+      "engines": {
+        "node": "> 0.1.90"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3829,7 +10515,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -3839,6 +10524,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-stable-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
+      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
+      "license": "MIT"
+    },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "license": "CC0-1.0",
+      "peer": true
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -3847,6 +10545,27 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/feaxios": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.23.tgz",
+      "integrity": "sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-retry-allowed": "^3.0.0"
+      }
+    },
+    "node_modules/feaxios/node_modules/is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-entry-cache": {
@@ -3861,6 +10580,12 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -3913,11 +10638,30 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -3927,6 +10671,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/framer-motion": {
@@ -3960,7 +10720,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3997,6 +10756,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.0"
+      }
+    },
     "node_modules/generator-function": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -4007,11 +10784,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4036,7 +10821,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -4133,7 +10917,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4148,6 +10931,23 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/h3": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-es": "^1.2.3",
+        "crossws": "^0.3.5",
+        "defu": "^6.1.6",
+        "destr": "^2.0.5",
+        "iron-webcrypto": "^1.2.1",
+        "node-mock-http": "^1.0.4",
+        "radix3": "^1.1.2",
+        "ufo": "^1.6.3",
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -4176,7 +10976,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -4205,7 +11004,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4218,7 +11016,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -4230,11 +11027,77 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hash-base": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/hash-base/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/hash-base/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/hash-base/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/hash-base/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/hash-base/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4242,6 +11105,114 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "license": "ISC"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
+      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -4258,6 +11229,7 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -4290,6 +11262,18 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/int64-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.1.1.tgz",
+      "integrity": "sha512-xp/v0/im2q7n7ISFJXcYsr/aVsUdZKPUZS1uYtoM9I9Cfmm5YuAi7SQts2TrEXwAKIE0wyn3KxJbo35goJgvwQ==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -4312,6 +11296,24 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/iron-webcrypto": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4385,6 +11387,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
@@ -4399,7 +11408,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4485,6 +11493,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -4531,6 +11548,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-my-ip-valid": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
+      "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==",
+      "license": "MIT"
+    },
+    "node_modules/is-my-json-valid": {
+      "version": "2.20.6",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.6.tgz",
+      "integrity": "sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==",
+      "license": "MIT",
+      "dependencies": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^5.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -4571,6 +11607,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -4588,6 +11630,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-set": {
@@ -4618,6 +11673,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-standalone-pwa": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/is-string": {
       "version": "1.1.1",
@@ -4658,7 +11733,6 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -4720,7 +11794,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -4729,6 +11802,30 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
@@ -4746,6 +11843,65 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/jayson": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.3.0.tgz",
+      "integrity": "sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "^3.4.33",
+        "@types/node": "^12.12.54",
+        "@types/ws": "^7.4.4",
+        "commander": "^2.20.3",
+        "delay": "^5.0.0",
+        "es6-promisify": "^5.0.0",
+        "eyes": "^0.1.8",
+        "isomorphic-ws": "^4.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "stream-json": "^1.9.1",
+        "uuid": "^8.3.2",
+        "ws": "^7.5.10"
+      },
+      "bin": {
+        "jayson": "bin/jayson.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jayson/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "license": "MIT"
+    },
+    "node_modules/jayson/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/jayson/node_modules/ws": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/jiti": {
@@ -4766,6 +11922,12 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/js-sha256": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.1.tgz",
+      "integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4808,6 +11970,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
@@ -4819,6 +11987,15 @@
       },
       "bin": {
         "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -4837,6 +12014,27 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4846,6 +12044,12 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/keyvaluestorage-interface": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
+      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==",
+      "license": "MIT"
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
@@ -5142,6 +12346,37 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.0.tgz",
+      "integrity": "sha512-DGVsqsOIHBww2DqnuZzW7QsuCdahp50ojuDaBPC7jUDRpYoH0z7kHBBYZewRzer75FwtrkmkKk7iOAwSaWdBmw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5165,6 +12400,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.5.tgz",
+      "integrity": "sha512-e0r9YBBgNCq1D1o5Dp8FMH0N5hsFtXDBiVa0qoJPHpakvZkmDKPRoGffZJII/XsHvj9An9blm+cRJ01yQqU+Dw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5176,6 +12417,21 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru_map": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
+      "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/lucide-react": {
@@ -5201,10 +12457,32 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "node_modules/merge2": {
@@ -5230,6 +12508,58 @@
       "engines": {
         "node": ">=8.6"
       }
+    },
+    "node_modules/miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      }
+    },
+    "node_modules/miller-rabin/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -5275,6 +12605,30 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "license": "(Apache-2.0 AND MIT)"
+    },
+    "node_modules/mustache": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.0.tgz",
+      "integrity": "sha512-FJgjyX/IVkbXBXYUwH+OYwQKqWpFPLaLVESd70yHjSDunwzV2hZOoTBvPf4KLoxesUzzyfTH6F784Uqd7Wm5yA==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -5316,11 +12670,72 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/near-abi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/near-abi/-/near-abi-0.2.0.tgz",
+      "integrity": "sha512-kCwSf/3fraPU2zENK18sh+kKG4uKbEUEQdyWQkmW8ZofmLarObIz2+zAYjA1teDZLeMvEQew3UysnPDXgjneaA==",
+      "license": "(MIT AND Apache-2.0)",
+      "dependencies": {
+        "@types/json-schema": "^7.0.11"
+      }
+    },
+    "node_modules/near-api-js": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/near-api-js/-/near-api-js-5.1.1.tgz",
+      "integrity": "sha512-h23BGSKxNv8ph+zU6snicstsVK1/CTXsQz4LuGGwoRE24Hj424nSe4+/1tzoiC285Ljf60kPAqRCmsfv9etF2g==",
+      "license": "(MIT AND Apache-2.0)",
+      "dependencies": {
+        "@near-js/accounts": "1.4.1",
+        "@near-js/crypto": "1.4.2",
+        "@near-js/keystores": "0.2.2",
+        "@near-js/keystores-browser": "0.2.2",
+        "@near-js/keystores-node": "0.1.2",
+        "@near-js/providers": "1.0.3",
+        "@near-js/signers": "0.2.2",
+        "@near-js/transactions": "1.3.3",
+        "@near-js/types": "0.3.1",
+        "@near-js/utils": "1.1.0",
+        "@near-js/wallet-account": "1.3.3",
+        "@noble/curves": "1.8.1",
+        "borsh": "1.0.0",
+        "depd": "2.0.0",
+        "http-errors": "1.7.2",
+        "near-abi": "0.2.0",
+        "node-fetch": "2.6.7"
+      }
+    },
+    "node_modules/near-api-js/node_modules/borsh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
+      "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/near-api-js/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next": {
       "version": "15.5.9",
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
       "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.5.9",
         "@swc/helpers": "0.5.15",
@@ -5403,6 +12818,73 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-mock-http": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
+      "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==",
+      "license": "MIT"
+    },
+    "node_modules/nofilter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
+      "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.19"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-assign": {
@@ -5528,6 +13010,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ofetch": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+      "license": "MIT",
+      "dependencies": {
+        "destr": "^2.0.5",
+        "node-fetch-native": "^1.6.7",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5564,6 +13066,43 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ox": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.9.tgz",
+      "integrity": "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -5596,6 +13135,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5609,11 +13157,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-asn1": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
+      "integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^4.10.1",
+        "browserify-aes": "^1.2.0",
+        "evp_bytestokey": "^1.0.3",
+        "pbkdf2": "^3.1.5",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5636,6 +13199,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pbkdf2": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.6.tgz",
+      "integrity": "sha512-BT6eelPB1EyGHo8pC0o9Bl6k6SYVhKO1jEbd3lcTrtr7XHdjP8BW1YpfCV3G9Kwkxgattk+S5q2/RvuttCsS1g==",
+      "license": "MIT",
+      "dependencies": {
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "ripemd160": "^2.0.3",
+        "safe-buffer": "^5.2.1",
+        "sha.js": "^2.4.12",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5646,7 +13226,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -5654,6 +13233,43 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/pino": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
     },
     "node_modules/plaiceholder": {
       "version": "3.0.0",
@@ -5664,11 +13280,19 @@
         "sharp": ">= 0.30.6"
       }
     },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5703,6 +13327,25 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/preact": {
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5712,6 +13355,28 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+      "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -5725,6 +13390,65 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
+      "integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/public-encrypt/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5733,6 +13457,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pushdata-bitcoin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
+      "integrity": "sha512-hw7rcYTJRAl4olM8Owe8x0fBuJJ+WGbMhQuLWOXEMN3PxPCKQHRkhfL+XG0+iXUmSHjkMmb3Ba55Mt21cZc9kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bitcoin-ops": "^1.3.0"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
+      "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "encode-utf8": "^1.0.3",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/qrcode.react": {
@@ -5765,11 +13516,43 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/radix3": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+      "license": "MIT"
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "license": "MIT",
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5779,6 +13562,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -5791,6 +13575,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -5838,13 +13623,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5871,6 +13658,42 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/recharts": {
@@ -5907,7 +13730,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -5961,6 +13785,34 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/require-addon": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/require-addon/-/require-addon-1.2.0.tgz",
+      "integrity": "sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-addon-resolve": "^1.3.0"
+      },
+      "engines": {
+        "bare": ">=1.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/reselect": {
       "version": "5.1.1",
@@ -6020,6 +13872,120 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ripemd160": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.1.2",
+        "inherits": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ripple-address-codec": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ripple-address-codec/-/ripple-address-codec-5.0.1.tgz",
+      "integrity": "sha512-JQHLKuVJV8lv9Qobmn4aUM2Dpv9WRRLKnNWfM8tN02fAbUtG8mUPsu9q9UYX8P76G4qzytEc5ZKMp/3JggNYmw==",
+      "license": "ISC",
+      "dependencies": {
+        "@scure/base": "^2.0.0",
+        "@xrplf/isomorphic": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/ripple-address-codec/node_modules/@scure/base": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.3.0.tgz",
+      "integrity": "sha512-NsG6Y03tY6R5BUis4FdVtHVkur0U6FOzskgs9ZXNl78CUc9fkZ78HmENUle1nSOkCasDmbubmWD9qwB7mm4PZA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ripple-binary-codec": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-2.9.0.tgz",
+      "integrity": "sha512-DOv4CPwm2B5mjAJNHE4tfes7tIqefi85iun8BskS7/i1PvLIwVydHIbTV5hbQ7eT69Zg4K5dtO1CzfuvQVAYvQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@xrplf/isomorphic": "^1.0.2",
+        "bignumber.js": "^10.0.2",
+        "ripple-address-codec": "^5.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/ripple-binary-codec/node_modules/bignumber.js": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-10.0.2.tgz",
+      "integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ==",
+      "license": "MIT"
+    },
+    "node_modules/ripple-keypairs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ripple-keypairs/-/ripple-keypairs-2.0.0.tgz",
+      "integrity": "sha512-b5rfL2EZiffmklqZk1W+dvSy97v3V/C7936WxCCgDynaGPp7GE6R2XO7EU9O2LlM/z95rj870IylYnOQs+1Rag==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/curves": "^1.0.0",
+        "@xrplf/isomorphic": "^1.0.0",
+        "ripple-address-codec": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/rpc-websockets": {
+      "version": "9.3.9",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.3.9.tgz",
+      "integrity": "sha512-2iQDaTB4g5fDB2ihrTFSJSibCEuxaRi1q7qTW7ZO9/M5/TC+ToHA4D9/ffNLEbAoHNNrcdeP05oATNk44SKZXA==",
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/uuid": "^10.0.0",
+        "@types/ws": "^8.2.2",
+        "buffer": "^6.0.3",
+        "eventemitter3": "^5.0.1",
+        "uuid": "^14.0.0",
+        "ws": "^8.5.0"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/kozjak"
+      },
+      "optionalDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^6.0.0"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/uuid": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
+      "integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6044,6 +14010,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -6063,6 +14038,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -6099,10 +14094,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
+    },
+    "node_modules/secp256k1": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-5.0.1.tgz",
+      "integrity": "sha512-lDFs9AAIaWP9UCdtWrotXWWF9t8PWgQDcxqgAnpM9rMqxb3Oaq2J0thzPVSxBwdJgyQtkU/sYtFtbM1RSt/iYA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "elliptic": "^6.5.7",
+        "node-addon-api": "^5.0.0",
+        "node-gyp-build": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/secp256k1/node_modules/node-addon-api": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -6117,11 +14142,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -6166,12 +14196,52 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+      "license": "ISC"
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sha1": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sha1/-/sha1-1.1.1.tgz",
+      "integrity": "sha512-dZBS6OrMjtgVkopB1Gmo4RQCDKiZsqcpAQpkV/aaj+FCrCg8r4I4qMkDPQjBgLIxlmu9k4nUbWq6ohXahOneYA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": ">= 0.0.1",
+        "crypt": ">= 0.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/sharp": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -6309,6 +14379,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/slow-redact": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.2.tgz",
+      "integrity": "sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==",
+      "license": "MIT"
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/socket.io-client": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
@@ -6337,6 +14435,53 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/sodium-native": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.3.tgz",
+      "integrity": "sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "require-addon": "^1.1.0"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -6356,12 +14501,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -6376,6 +14539,60 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stream-json": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-chain": "^2.2.5"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
@@ -6490,6 +14707,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -6513,6 +14742,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/style-vendorizer": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/style-vendorizer/-/style-vendorizer-2.2.3.tgz",
+      "integrity": "sha512-/VDRsWvQAgspVy9eATN3z6itKTuyg+jW1q6UoTCQCFRqPDw8bi3E1hXIKnGw5LvXS2AQPuJ7Af4auTLYeBOLEg==",
+      "license": "MIT"
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -6534,6 +14769,15 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/superstruct": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
+      "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/supports-color": {
@@ -6583,10 +14827,47 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/text-encoding-utf-8": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
+      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
+    },
+    "node_modules/thread-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-secp256k1": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.7.tgz",
+      "integrity": "sha512-eb+F6NabSnjbLwNoC+2o5ItbmP1kg7HliWue71JgLegQt6A5mTN8YbvTLCazdlg6e5SV6A+r8OGvZYskdlmhqQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.3.0",
+        "bn.js": "^4.11.8",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.4.0",
+        "nan": "^2.13.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/tiny-secp256k1/node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -6630,11 +14911,26 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/to-regex-range": {
@@ -6650,6 +14946,27 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -6662,6 +14979,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -6680,7 +15003,20 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
+    "node_modules/tweetnacl-util": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
+      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6699,7 +15035,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -6773,18 +15108,111 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typeforce": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/ua-is-frozen": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ua-parser-js": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.10.tgz",
+      "integrity": "sha512-t+3Ktbq0Ies2vaSezfOaWiolH4OigQIO1dk+1xDpOydB1COVPocVYOrEV5rqZ0kFY9XYG1v9LutCyMgYBpABcw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "detect-europe-js": "^0.1.2",
+        "is-standalone-pwa": "^0.1.1",
+        "ua-is-frozen": "^0.1.2"
+      },
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "license": "MIT"
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/uint8array-tools": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.8.tgz",
+      "integrity": "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "license": "MIT",
+      "dependencies": {
+        "multiformats": "^9.4.2"
       }
     },
     "node_modules/unbox-primitive": {
@@ -6806,11 +15234,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -6848,6 +15281,102 @@
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
       }
     },
+    "node_modules/unstorage": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+      "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^3.1.3",
+        "chokidar": "^5.0.0",
+        "destr": "^2.0.5",
+        "h3": "^1.15.10",
+        "lru-cache": "^11.2.7",
+        "node-fetch-native": "^1.6.7",
+        "ofetch": "^1.5.1",
+        "ufo": "^1.6.3"
+      },
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.8.0",
+        "@azure/cosmos": "^4.2.0",
+        "@azure/data-tables": "^13.3.0",
+        "@azure/identity": "^4.6.0",
+        "@azure/keyvault-secrets": "^4.9.0",
+        "@azure/storage-blob": "^12.26.0",
+        "@capacitor/preferences": "^6 || ^7 || ^8",
+        "@deno/kv": ">=0.9.0",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+        "@planetscale/database": "^1.19.0",
+        "@upstash/redis": "^1.34.3",
+        "@vercel/blob": ">=0.27.1",
+        "@vercel/functions": "^2.2.12 || ^3.0.0",
+        "@vercel/kv": "^1 || ^2 || ^3",
+        "aws4fetch": "^1.0.20",
+        "db0": ">=0.2.1",
+        "idb-keyval": "^6.2.1",
+        "ioredis": "^5.4.2",
+        "uploadthing": "^7.4.4"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@capacitor/preferences": {
+          "optional": true
+        },
+        "@deno/kv": {
+          "optional": true
+        },
+        "@netlify/blobs": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/blob": {
+          "optional": true
+        },
+        "@vercel/functions": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "aws4fetch": {
+          "optional": true
+        },
+        "db0": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "uploadthing": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -6858,13 +15387,113 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "license": "MIT"
+    },
+    "node_modules/usb": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-2.18.0.tgz",
+      "integrity": "sha512-klAJPUTaSxRvTgrIh7om6UTrgRxdzioD+rJc/MaoiN8+OGdqRzai39tR00asnoCesPNikItWB9zBZoo0pJsWaA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/w3c-web-usb": "^1.0.6",
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=12.22.0 <13.0 || >=14.17.0"
+      }
+    },
+    "node_modules/usb/node_modules/node-addon-api": {
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utf-8-validate": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
+      "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uuid4": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/uuid4/-/uuid4-2.0.3.tgz",
+      "integrity": "sha512-CTpAkEVXMNJl2ojgtpLXHgz23dh8z81u6/HEPiQFOvBc/c2pde6TVHmH4uwY0d/GLF3tb7+VDAj4+2eJaQSdZQ==",
+      "license": "ISC"
+    },
+    "node_modules/valtio": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-2.1.7.tgz",
+      "integrity": "sha512-DwJhCDpujuQuKdJ2H84VbTjEJJteaSmqsuUltsfbfdbotVfNeTE4K/qc/Wi57I9x8/2ed4JNdjEna7O6PfavRg==",
+      "license": "MIT",
+      "dependencies": {
+        "proxy-compare": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/varuint-bitcoin": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-2.0.0.tgz",
+      "integrity": "sha512-6QZbU/rHO2ZQYpWFDALCDSRsXbAs1VOEmXAxtbtjLtKuMJ/FQ8YbhfxlaiKv5nklci0M6lZtlZyxo9Q+qNnyog==",
+      "license": "MIT",
+      "dependencies": {
+        "uint8array-tools": "^0.0.8"
       }
     },
     "node_modules/victory-vendor": {
@@ -6887,6 +15516,157 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/viem": {
+      "version": "2.55.19",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.55.19.tgz",
+      "integrity": "sha512-4QPIX0eYPLsOBk53NKswVMkQoxuP7GlOBnB4wM6dkDokREO4QENNc3bmyPKK1PBTViXh0TPJCHLjIuU20Qi3fg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.34",
+        "ws": "8.21.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/viem/node_modules/ox": {
+      "version": "0.14.34",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.34.tgz",
+      "integrity": "sha512-12seOIk7dv8eAoGQhcWaeKZxNz304IVcDvb9U5Y7JZAEVe21Nm1YMxLjhWah+su5BD4Omx4Zz0z5x3ij9M4GYQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -6972,11 +15752,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
       "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -6994,6 +15779,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wif": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-5.0.0.tgz",
+      "integrity": "sha512-iFzrC/9ne740qFbNjTZ2FciSRJlHIXoxqk/Y5EnE08QOXu1WjJyCCswwDTYbohAOEnlCtLaAAQBhyaLRFh2hMA==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58check": "^4.0.0"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -7004,11 +15798,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ws": {
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -7033,6 +15842,129 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/xrpl": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/xrpl/-/xrpl-4.4.3.tgz",
+      "integrity": "sha512-vi2OjuNkiaP8nv1j+nqHp8GZwwEjO6Y8+j/OuVMg6M4LwXEwyHdIj33dlg7cyY1Lw5+jb9HqFOQvABhaywVbTQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@scure/bip32": "^1.3.1",
+        "@scure/bip39": "^1.2.1",
+        "@xrplf/isomorphic": "^1.0.1",
+        "@xrplf/secret-numbers": "^2.0.0",
+        "bignumber.js": "^9.0.0",
+        "eventemitter3": "^5.0.1",
+        "fast-json-stable-stringify": "^2.1.0",
+        "ripple-address-codec": "^5.0.0",
+        "ripple-binary-codec": "^2.5.0",
+        "ripple-keypairs": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -7051,6 +15983,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -256,6 +256,16 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/@coinbase/cdp-sdk/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@coinbase/wallet-sdk": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-4.3.6.tgz",
@@ -439,7 +449,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.1.1"
       },
@@ -561,6 +570,21 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@creit.tech/stellar-wallets-kit/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/@creit.tech/xbull-wallet-connect": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@creit.tech/xbull-wallet-connect/-/xbull-wallet-connect-0.4.0.tgz",
@@ -650,13 +674,15 @@
       "version": "13.2.1",
       "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-browser/-/cardano-serialization-lib-browser-13.2.1.tgz",
       "integrity": "sha512-7RfX1gI16Vj2DgCp/ZoXqyLAakWo6+X95ku/rYGbVzuS/1etrlSiJmdbmdm+eYmszMlGQjrtOJQeVLXoj4L/Ag==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@emurgo/cardano-serialization-lib-nodejs": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-nodejs/-/cardano-serialization-lib-nodejs-13.2.0.tgz",
       "integrity": "sha512-Bz1zLGEqBQ0BVkqt1OgMxdBOE3BdUWUd7Ly9Ecr/aUwkA8AV1w1XzBMe4xblmJHnB1XXNlPH4SraXCvO+q0Mig==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -807,6 +833,7 @@
       "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-10.1.3.tgz",
       "integrity": "sha512-ECWwbc4s8Ji7U0mkfZP6gIDy1FxXe0ZyVOTt0adkztPQRzX2DbH2ul7a83DSS8qYAiG6//vVXMkP60TyYOnv8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethereumjs/util": "^10.1.3",
         "eventemitter3": "^5.0.1"
@@ -817,6 +844,7 @@
       "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-10.1.3.tgz",
       "integrity": "sha512-d795YWkN6O8EJh/PgJ2zZKCdBMl8OlqkuVQESoidH666gaFtUuJ01jDtiuqfyOqTNcTdGhHi8LkQv1WEZzvZZw==",
       "license": "MPL-2.0",
+      "peer": true,
       "bin": {
         "rlp": "bin/rlp.cjs"
       },
@@ -829,6 +857,7 @@
       "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-10.1.3.tgz",
       "integrity": "sha512-5uk9qB2MjyF4axL6GGPvYODe3uR/h6k36boDbvjH81WYFphw/JAIrI1thkWQX4BCyF8bi6suxORhi+vDc3lPlg==",
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "@ethereumjs/common": "^10.1.3",
         "@ethereumjs/rlp": "^10.1.3",
@@ -845,6 +874,7 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.3.0.tgz",
       "integrity": "sha512-v7cY+4oWYPQszRj6ZFGzTVL7uP2TaLo1xMhWHzYC5wj0ZhOXQ5x+sBre8rF3hi8cAoi0bh1qXoovoOkdFtvqEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "2.3.0"
       },
@@ -860,6 +890,7 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
       "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -872,6 +903,7 @@
       "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-10.1.3.tgz",
       "integrity": "sha512-PhezOVe4DFaC+QLIsnK/tiOaXjpjS2F9AH4Ez0EfWevFw9NWNSg95l7I0dWuHF0B7v9odm2Ijqwo0EnARXtUmA==",
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "@ethereumjs/rlp": "^10.1.3",
         "@noble/curves": "^2.0.1",
@@ -886,6 +918,7 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.3.0.tgz",
       "integrity": "sha512-v7cY+4oWYPQszRj6ZFGzTVL7uP2TaLo1xMhWHzYC5wj0ZhOXQ5x+sBre8rF3hi8cAoi0bh1qXoovoOkdFtvqEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "2.3.0"
       },
@@ -901,6 +934,7 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
       "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -913,6 +947,7 @@
       "resolved": "https://registry.npmjs.org/@fivebinaries/coin-selection/-/coin-selection-3.0.0.tgz",
       "integrity": "sha512-h25Pn1ZA7oqQBQDodGAgIsQt66T2wDge9onBKNqE66WNWL0KJiKJbpij8YOLo5AAlEIg5IS7EB1QjBgDOIg6DQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@emurgo/cardano-serialization-lib-browser": "^13.2.0",
         "@emurgo/cardano-serialization-lib-nodejs": "13.2.0"
@@ -1608,6 +1643,7 @@
       "resolved": "https://registry.npmjs.org/@mobily/ts-belt/-/ts-belt-3.13.1.tgz",
       "integrity": "sha512-K5KqIhPI/EoCTbA6CGbrenM9s41OouyK8A03fGJJcla/zKucsgLbz8HNbeseoLarRPgyWJsUyCYqFhI7t3Ra9Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.*"
       }
@@ -1639,6 +1675,7 @@
       "resolved": "https://registry.npmjs.org/@near-js/accounts/-/accounts-1.4.1.tgz",
       "integrity": "sha512-ni3QT9H3NdrbVVKyx56yvz93r89Dvpc/vgVtiIK2OdXjkK6jcj+UKMDRQ6F7rd9qJOInLkHZbVBtcR6j1CXLjw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@near-js/crypto": "1.4.2",
         "@near-js/providers": "1.0.3",
@@ -1658,7 +1695,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
       "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@near-js/crypto": {
       "version": "1.4.2",
@@ -1685,6 +1723,7 @@
       "resolved": "https://registry.npmjs.org/@near-js/keystores/-/keystores-0.2.2.tgz",
       "integrity": "sha512-DLhi/3a4qJUY+wgphw2Jl4S+L0AKsUYm1mtU0WxKYV5OBwjOXvbGrXNfdkheYkfh3nHwrQgtjvtszX6LrRXLLw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@near-js/crypto": "1.4.2",
         "@near-js/types": "0.3.1"
@@ -1695,6 +1734,7 @@
       "resolved": "https://registry.npmjs.org/@near-js/keystores-browser/-/keystores-browser-0.2.2.tgz",
       "integrity": "sha512-Pxqm7WGtUu6zj32vGCy9JcEDpZDSB5CCaLQDTQdF3GQyL0flyRv2I/guLAgU5FLoYxU7dJAX9mslJhPW7P2Bfw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@near-js/crypto": "1.4.2",
         "@near-js/keystores": "0.2.2"
@@ -1705,6 +1745,7 @@
       "resolved": "https://registry.npmjs.org/@near-js/keystores-node/-/keystores-node-0.1.2.tgz",
       "integrity": "sha512-MWLvTszZOVziiasqIT/LYNhUyWqOJjDGlsthOsY6dTL4ZcXjjmhmzrbFydIIeQr+CcEl5wukTo68ORI9JrHl6g==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@near-js/crypto": "1.4.2",
         "@near-js/keystores": "0.2.2"
@@ -1715,6 +1756,7 @@
       "resolved": "https://registry.npmjs.org/@near-js/providers/-/providers-1.0.3.tgz",
       "integrity": "sha512-VJMboL14R/+MGKnlhhE3UPXCGYvMd1PpvF9OqZ9yBbulV7QVSIdTMfY4U1NnDfmUC2S3/rhAEr+3rMrIcNS7Fg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@near-js/transactions": "1.3.3",
         "@near-js/types": "0.3.1",
@@ -1730,7 +1772,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
       "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@near-js/providers/node_modules/node-fetch": {
       "version": "2.6.7",
@@ -1738,6 +1781,7 @@
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -1758,6 +1802,7 @@
       "resolved": "https://registry.npmjs.org/@near-js/signers/-/signers-0.2.2.tgz",
       "integrity": "sha512-M6ib+af9zXAPRCjH2RyIS0+RhCmd9gxzCeIkQ+I2A3zjgGiEDkBZbYso9aKj8Zh2lPKKSH7h+u8JGymMOSwgyw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@near-js/crypto": "1.4.2",
         "@near-js/keystores": "0.2.2",
@@ -1769,6 +1814,7 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
       "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -1781,6 +1827,7 @@
       "resolved": "https://registry.npmjs.org/@near-js/transactions/-/transactions-1.3.3.tgz",
       "integrity": "sha512-1AXD+HuxlxYQmRTLQlkVmH+RAmV3HwkAT8dyZDu+I2fK/Ec9BQHXakOJUnOBws3ihF+akQhamIBS5T0EXX/Ylw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@near-js/crypto": "1.4.2",
         "@near-js/signers": "0.2.2",
@@ -1794,7 +1841,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
       "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@near-js/types": {
       "version": "0.3.1",
@@ -1819,6 +1867,7 @@
       "resolved": "https://registry.npmjs.org/@near-js/wallet-account/-/wallet-account-1.3.3.tgz",
       "integrity": "sha512-GDzg/Kz0GBYF7tQfyQQQZ3vviwV8yD+8F2lYDzsWJiqIln7R1ov0zaXN4Tii86TeS21KPn2hHAsVu3Y4txa8OQ==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@near-js/accounts": "1.4.1",
         "@near-js/crypto": "1.4.2",
@@ -1835,7 +1884,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
       "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@near-wallet-selector/core": {
       "version": "8.10.2",
@@ -2151,31 +2201,36 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
       "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
       "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1"
       }
@@ -2184,31 +2239,36 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
       "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
       "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
@@ -2532,7 +2592,8 @@
       "version": "0.33.24",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.33.24.tgz",
       "integrity": "sha512-91up4t0BLjfkCZ4Ap/BcgaPrMaX6n0I2YRu+kc03xGhLy9G3N05nbTpnK8q7GXdv0PxwUoxi67A8o3Wr5U7j3w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
@@ -2896,6 +2957,48 @@
         "@solana/codecs-strings": "5.5.1",
         "@solana/errors": "5.5.1",
         "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
+      "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/accounts": "5.5.1",
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instruction-plans": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/offchain-messages": "5.5.1",
+        "@solana/plugin-core": "5.5.1",
+        "@solana/programs": "5.5.1",
+        "@solana/rpc": "5.5.1",
+        "@solana/rpc-api": "5.5.1",
+        "@solana/rpc-parsed-types": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-subscriptions": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/signers": "5.5.1",
+        "@solana/sysvars": "5.5.1",
+        "@solana/transaction-confirmation": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -3568,7 +3671,6 @@
       "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz",
       "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "@noble/curves": "^1.4.2",
@@ -3716,7 +3818,8 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
       "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@stellar/stellar-base": {
       "version": "13.1.0",
@@ -3724,6 +3827,7 @@
       "integrity": "sha512-90EArG+eCCEzDGj3OJNoCtwpWDwxjv+rs/RNPhvg4bulpjN/CSRj+Ys/SalRcfM4/WRC5/qAfjzmJBAuquWhkA==",
       "deprecated": "This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@stellar/js-xdr": "^3.1.2",
         "base32.js": "^0.1.0",
@@ -3744,6 +3848,7 @@
       "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-13.3.0.tgz",
       "integrity": "sha512-8+GHcZLp+mdin8gSjcgfb/Lb6sSMYRX6Nf/0LcSJxvjLQR0XHpjGzOiRbYb2jSXo51EnA6kAV5j+4Pzh5OUKUg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@stellar/stellar-base": "^13.1.0",
         "axios": "^1.8.4",
@@ -3763,6 +3868,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
       "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
@@ -4135,7 +4241,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.19.tgz",
       "integrity": "sha512-qTZRZ4QyTzQc+M0IzrbKHxSeISUmRB3RPGmao5bT+sI6ayxSRhn0FXEnT5Hg3as8SBFcRosrXXRFB+yAcxVxJQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.19"
       },
@@ -4202,6 +4307,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/analytics/-/analytics-1.5.0.tgz",
       "integrity": "sha512-evILW5XJEmfPlf0TY1duOLtGJ47pdGeSKVE3P75ODEUsRNxtPVqlkOUBPmYpCxPnzS8XDmkatT8lf9/DF0G6nA==",
       "license": "See LICENSE.md in repo root",
+      "peer": true,
       "dependencies": {
         "@trezor/env-utils": "1.5.0",
         "@trezor/utils": "9.5.0"
@@ -4215,6 +4321,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/env-utils/-/env-utils-1.5.0.tgz",
       "integrity": "sha512-u1TN7dMQ5Qhpbae08Z4JJmI9fQrbbJ4yj8eIAsuzMQn6vb+Sg9vbntl+IDsZ1G9WeI73uHTLu1wWMmAgiujH8w==",
       "license": "See LICENSE.md in repo root",
+      "peer": true,
       "dependencies": {
         "ua-parser-js": "^2.0.4"
       },
@@ -4241,6 +4348,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/blockchain-link/-/blockchain-link-2.6.2.tgz",
       "integrity": "sha512-HMz+Dm6nMflqRkaebMqpv3uNnVkRrb6lD2HKTHNBGhjVbqf0wRzJ8JoQ08wn/sF00ljJZz8pGnpcMYHJNxE+wQ==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
       "dependencies": {
         "@solana-program/compute-budget": "^0.8.0",
         "@solana-program/stake": "^0.2.1",
@@ -4270,6 +4378,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-types/-/blockchain-link-types-1.5.1.tgz",
       "integrity": "sha512-Idavz6LwLBW8sXc69fh5AJEnl666EDl2Nt3io7updvBgOR0/P12I900DgjNhCKtiWuv66A33/5RE7zLcj3lfnw==",
       "license": "See LICENSE.md in repo root",
+      "peer": true,
       "dependencies": {
         "@trezor/utils": "9.5.0",
         "@trezor/utxo-lib": "2.5.0"
@@ -4283,6 +4392,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-utils/-/blockchain-link-utils-1.5.2.tgz",
       "integrity": "sha512-OSS5OEE98FMnYfjoEALPjBt7ebjC/FKnq3HOolHdEWXBpVlXZNN2+Vo1R9J6WbZUU087sHuUTJJy/GJYWY13Tg==",
       "license": "See LICENSE.md in repo root",
+      "peer": true,
       "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
         "@stellar/stellar-sdk": "14.2.0",
@@ -4300,6 +4410,7 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
       "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.8.0"
       },
@@ -4315,6 +4426,7 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4328,6 +4440,7 @@
       "integrity": "sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw==",
       "deprecated": "This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@noble/curves": "^1.9.6",
         "@stellar/js-xdr": "^3.1.2",
@@ -4346,6 +4459,7 @@
       "integrity": "sha512-7nh2ogzLRMhfkIC0fGjn1LHUzk3jqVw8tjAuTt5ADWfL9CSGBL18ILucE9igz2L/RU2AZgeAvhujAnW91Ut/oQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@stellar/stellar-base": "^14.0.1",
         "axios": "^1.12.2",
@@ -4365,6 +4479,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/env-utils/-/env-utils-1.5.0.tgz",
       "integrity": "sha512-u1TN7dMQ5Qhpbae08Z4JJmI9fQrbbJ4yj8eIAsuzMQn6vb+Sg9vbntl+IDsZ1G9WeI73uHTLu1wWMmAgiujH8w==",
       "license": "See LICENSE.md in repo root",
+      "peer": true,
       "dependencies": {
         "ua-parser-js": "^2.0.4"
       },
@@ -4391,6 +4506,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.5.2.tgz",
       "integrity": "sha512-zViaL1jKue8DUTVEDg0C/lMipqNMd/Z3kr29/+MeZOoupjaXIQ2Lqp3WAMe8hvNTKKX8aNQH9JrbapJ6w9FMXw==",
       "license": "See LICENSE.md in repo root",
+      "peer": true,
       "dependencies": {
         "@trezor/schema-utils": "1.4.0",
         "long": "5.2.5",
@@ -4406,6 +4522,7 @@
       "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -4429,6 +4546,7 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
       "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.8.0"
       },
@@ -4444,6 +4562,7 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4456,6 +4575,7 @@
       "resolved": "https://registry.npmjs.org/@solana-program/compute-budget/-/compute-budget-0.8.0.tgz",
       "integrity": "sha512-qPKxdxaEsFxebZ4K5RPuy7VQIm/tfJLa1+Nlt3KNA8EYQkz9Xm8htdoEaXVrer9kpgzzp9R3I3Bh6omwCM06tQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@solana/kit": "^2.1.0"
       }
@@ -4465,6 +4585,7 @@
       "resolved": "https://registry.npmjs.org/@solana-program/stake/-/stake-0.2.1.tgz",
       "integrity": "sha512-ssNPsJv9XHaA+L7ihzmWGYcm/+XYURQ8UA3wQMKf6ccEHyHOUgoglkkDU/BoA0+wul6HxZUN0tHFymC0qFw6sg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@solana/kit": "^2.1.0"
       }
@@ -4474,6 +4595,7 @@
       "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.5.1.tgz",
       "integrity": "sha512-bJvynW5q9SFuVOZ5vqGVkmaPGA0MCC+m9jgJj1nk5m20I389/ms69ASnhWGoOPNcie7S9OwBX0gTj2fiyWpfag==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@solana/kit": "^2.1.0"
       }
@@ -4483,6 +4605,7 @@
       "resolved": "https://registry.npmjs.org/@solana-program/token-2022/-/token-2022-0.4.2.tgz",
       "integrity": "sha512-zIpR5t4s9qEU3hZKupzIBxJ6nUV5/UVyIT400tu9vT1HMs5JHxaTTsb5GUhYjiiTvNwU0MQavbwc4Dl29L0Xvw==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@solana/kit": "^2.1.0",
         "@solana/sysvars": "^2.1.0"
@@ -4493,6 +4616,7 @@
       "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.3.0.tgz",
       "integrity": "sha512-QgQTj404Z6PXNOyzaOpSzjgMOuGwG8vC66jSDB+3zHaRcEPRVRd2sVSrd1U6sHtnV3aiaS6YyDuPQMheg4K2jw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "2.3.0",
         "@solana/codecs-core": "2.3.0",
@@ -4513,6 +4637,7 @@
       "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.3.0.tgz",
       "integrity": "sha512-ypTNkY2ZaRFpHLnHAgaW8a83N0/WoqdFvCqf4CQmnMdFsZSdC7qOwcbd7YzdaQn9dy+P2hybewzB+KP7LutxGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/assertions": "2.3.0",
         "@solana/codecs-core": "2.3.0",
@@ -4532,6 +4657,7 @@
       "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.3.0.tgz",
       "integrity": "sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0"
       },
@@ -4547,6 +4673,7 @@
       "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.3.0.tgz",
       "integrity": "sha512-JVqGPkzoeyU262hJGdH64kNLH0M+Oew2CIPOa/9tR3++q2pEd4jU2Rxdfye9sd0Ce3XJrR5AIa8ZfbyQXzjh+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "2.3.0",
         "@solana/codecs-data-structures": "2.3.0",
@@ -4566,6 +4693,7 @@
       "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
       "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0"
       },
@@ -4581,6 +4709,7 @@
       "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.3.0.tgz",
       "integrity": "sha512-qvU5LE5DqEdYMYgELRHv+HMOx73sSoV1ZZkwIrclwUmwTbTaH8QAJURBj0RhQ/zCne7VuLLOZFFGv6jGigWhSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "2.3.0",
         "@solana/codecs-numbers": "2.3.0",
@@ -4598,6 +4727,7 @@
       "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
       "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "2.3.0",
         "@solana/errors": "2.3.0"
@@ -4614,6 +4744,7 @@
       "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.3.0.tgz",
       "integrity": "sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "2.3.0",
         "@solana/codecs-numbers": "2.3.0",
@@ -4632,6 +4763,7 @@
       "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
       "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^5.4.1",
         "commander": "^14.0.0"
@@ -4651,6 +4783,7 @@
       "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.3.0.tgz",
       "integrity": "sha512-KfJPrMEieUg6D3hfQACoPy0ukrAV8Kio883llt/8chPEG3FVTX9z/Zuf4O01a15xZmBbmQ7toil2Dp0sxMJSxw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -4663,6 +4796,7 @@
       "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.3.0.tgz",
       "integrity": "sha512-AgsPh3W3tE+nK3eEw/W9qiSfTGwLYEvl0rWaxHht/lRcuDVwfKRzeSa5G79eioWFFqr+pTtoCr3D3OLkwKz02Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -4675,6 +4809,7 @@
       "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.3.0.tgz",
       "integrity": "sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "2.3.0",
         "@solana/errors": "2.3.0"
@@ -4691,6 +4826,7 @@
       "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.3.0.tgz",
       "integrity": "sha512-ZVVdga79pNH+2pVcm6fr2sWz9HTwfopDVhYb0Lh3dh+WBmJjwkabXEIHey2rUES7NjFa/G7sV8lrUn/v8LDCCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/assertions": "2.3.0",
         "@solana/codecs-core": "2.3.0",
@@ -4743,6 +4879,7 @@
       "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-2.3.0.tgz",
       "integrity": "sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -4755,6 +4892,7 @@
       "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.3.0.tgz",
       "integrity": "sha512-PPnnZBRCWWoZQ11exPxf//DRzN2C6AoFsDI/u2AsQfYih434/7Kp4XLpfOMT/XESi+gdBMFNNfbES5zg3wAIkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "2.3.0",
         "@solana/codecs-data-structures": "2.3.0",
@@ -4774,6 +4912,7 @@
       "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.3.0.tgz",
       "integrity": "sha512-UXKujV71VCI5uPs+cFdwxybtHZAIZyQkqDiDnmK+DawtOO9mBn4Nimdb/6RjR2CXT78mzO9ZCZ3qfyX+ydcB7w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "2.3.0",
         "@solana/errors": "2.3.0"
@@ -4790,6 +4929,7 @@
       "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.3.0.tgz",
       "integrity": "sha512-GjVgutZKXVuojd9rWy1PuLnfcRfqsaCm7InCiZc8bqmJpoghlyluweNc7ml9Y5yQn1P2IOyzh9+p/77vIyNybQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -4802,6 +4942,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.3.0.tgz",
       "integrity": "sha512-ZWN76iNQAOCpYC7yKfb3UNLIMZf603JckLKOOLTHuy9MZnTN8XV6uwvDFhf42XvhglgUjGCEnbUqWtxQ9pa/pQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0",
         "@solana/fast-stable-stringify": "2.3.0",
@@ -4825,6 +4966,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.3.0.tgz",
       "integrity": "sha512-UUdiRfWoyYhJL9PPvFeJr4aJ554ob2jXcpn4vKmRVn9ire0sCbpQKYx6K8eEKHZWXKrDW8IDspgTl0gT/aJWVg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "2.3.0",
         "@solana/codecs-core": "2.3.0",
@@ -4850,6 +4992,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.3.0.tgz",
       "integrity": "sha512-B5pHzyEIbBJf9KHej+zdr5ZNAdSvu7WLU2lOUPh81KHdHQs6dEb310LGxcpCc7HVE8IEdO20AbckewDiAN6OCg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -4862,6 +5005,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.3.0.tgz",
       "integrity": "sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0",
         "@solana/rpc-spec-types": "2.3.0"
@@ -4878,6 +5022,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.3.0.tgz",
       "integrity": "sha512-xQsb65lahjr8Wc9dMtP7xa0ZmDS8dOE2ncYjlvfyw/h4mpdXTUdrSMi6RtFwX33/rGuztQ7Hwaid5xLNSLvsFQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -4890,6 +5035,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.3.0.tgz",
       "integrity": "sha512-Uyr10nZKGVzvCOqwCZgwYrzuoDyUdwtgQRefh13pXIrdo4wYjVmoLykH49Omt6abwStB0a4UL5gX9V4mFdDJZg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0",
         "@solana/fast-stable-stringify": "2.3.0",
@@ -4915,6 +5061,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.3.0.tgz",
       "integrity": "sha512-9mCjVbum2Hg9KGX3LKsrI5Xs0KX390lS+Z8qB80bxhar6MJPugqIPH8uRgLhCW9GN3JprAfjRNl7our8CPvsPQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "2.3.0",
         "@solana/keys": "2.3.0",
@@ -4936,6 +5083,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-2.3.0.tgz",
       "integrity": "sha512-2oL6ceFwejIgeWzbNiUHI2tZZnaOxNTSerszcin7wYQwijxtpVgUHiuItM/Y70DQmH9sKhmikQp+dqeGalaJxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0",
         "@solana/functional": "2.3.0",
@@ -4955,6 +5103,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.3.0.tgz",
       "integrity": "sha512-rdmVcl4PvNKQeA2l8DorIeALCgJEMSu7U8AXJS1PICeb2lQuMeaR+6cs/iowjvIB0lMVjYN2sFf6Q3dJPu6wWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0",
         "@solana/promises": "2.3.0",
@@ -4973,6 +5122,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.3.0.tgz",
       "integrity": "sha512-UuHYK3XEpo9nMXdjyGKkPCOr7WsZsxs7zLYDO1A5ELH3P3JoehvrDegYRAGzBS2VKsfApZ86ZpJToP0K3PhmMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0",
         "@solana/functional": "2.3.0",
@@ -4992,6 +5142,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.3.0.tgz",
       "integrity": "sha512-HFKydmxGw8nAF5N+S0NLnPBDCe5oMDtI2RAmW8DMqP4U3Zxt2XWhvV1SNkAldT5tF0U1vP+is6fHxyhk4xqEvg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0",
         "@solana/rpc-spec": "2.3.0",
@@ -5010,6 +5161,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.3.0.tgz",
       "integrity": "sha512-O09YX2hED2QUyGxrMOxQ9GzH1LlEwwZWu69QbL4oYmIf6P5dzEEHcqRY6L1LsDVqc/dzAdEs/E1FaPrcIaIIPw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "2.3.0",
         "@solana/codecs-core": "2.3.0",
@@ -5030,6 +5182,7 @@
       "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.3.0.tgz",
       "integrity": "sha512-OSv6fGr/MFRx6J+ZChQMRqKNPGGmdjkqarKkRzkwmv7v8quWsIRnJT5EV8tBy3LI4DLO/A8vKiNSPzvm1TdaiQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "2.3.0",
         "@solana/codecs-core": "2.3.0",
@@ -5052,6 +5205,7 @@
       "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-2.3.0.tgz",
       "integrity": "sha512-DkgohEDbMkdTWiKAoatY02Njr56WXx9e/dKKfmne8/Ad6/2llUIrax78nCdlvZW9quXMaXPTxZvdQqo9N669Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0"
       },
@@ -5086,6 +5240,7 @@
       "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.3.0.tgz",
       "integrity": "sha512-UiEuiHCfAAZEKdfne/XljFNJbsKAe701UQHKXEInYzIgBjRbvaeYZlBmkkqtxwcasgBTOmEaEKT44J14N9VZDw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "2.3.0",
         "@solana/codecs-strings": "2.3.0",
@@ -5110,6 +5265,7 @@
       "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.3.0.tgz",
       "integrity": "sha512-bgqvWuy3MqKS5JdNLH649q+ngiyOu5rGS3DizSnWwYUd76RxZl1kN6CoqHSrrMzFMvis6sck/yPGG3wqrMlAww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "2.3.0",
         "@solana/codecs-core": "2.3.0",
@@ -5133,6 +5289,7 @@
       "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.3.0.tgz",
       "integrity": "sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "2.3.0",
         "@solana/codecs-core": "2.3.0",
@@ -5160,6 +5317,7 @@
       "integrity": "sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw==",
       "deprecated": "This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@noble/curves": "^1.9.6",
         "@stellar/js-xdr": "^3.1.2",
@@ -5178,6 +5336,7 @@
       "integrity": "sha512-7nh2ogzLRMhfkIC0fGjn1LHUzk3jqVw8tjAuTt5ADWfL9CSGBL18ILucE9igz2L/RU2AZgeAvhujAnW91Ut/oQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@stellar/stellar-base": "^14.0.1",
         "axios": "^1.12.2",
@@ -5197,6 +5356,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/env-utils/-/env-utils-1.5.0.tgz",
       "integrity": "sha512-u1TN7dMQ5Qhpbae08Z4JJmI9fQrbbJ4yj8eIAsuzMQn6vb+Sg9vbntl+IDsZ1G9WeI73uHTLu1wWMmAgiujH8w==",
       "license": "See LICENSE.md in repo root",
+      "peer": true,
       "dependencies": {
         "ua-parser-js": "^2.0.4"
       },
@@ -5223,6 +5383,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -5234,13 +5395,15 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.29.0.tgz",
       "integrity": "sha512-vamA8dGlzMwhpyYpQp9d8vka3o4D/yn5I7ez7Or+msDA4bZ8Uh+Zy91WvWf3I73gDAkFha9JcYRqm2li0Npfgg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@trezor/connect": {
       "version": "9.7.3",
       "resolved": "https://registry.npmjs.org/@trezor/connect/-/connect-9.7.3.tgz",
       "integrity": "sha512-oAOfvJHT8tPqOXTmCOhn8uTZcoqSDuWAiWXQegx7C46tq+NLg+enkYXxUYEHq/9PmfZAOrUT9VMxZDsXM2thkA==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
       "dependencies": {
         "@ethereumjs/common": "^10.1.0",
         "@ethereumjs/tx": "^10.1.0",
@@ -5285,6 +5448,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/connect-analytics/-/connect-analytics-1.4.0.tgz",
       "integrity": "sha512-hy2J2oeIhRC/e1bOWXo5dsVMVnDwO2UKnxhR6FD8PINR3jgM6PWAXc6k33WJsBcyiTzwMP7/xPysLcgNJH5o4w==",
       "license": "See LICENSE.md in repo root",
+      "peer": true,
       "dependencies": {
         "@trezor/analytics": "1.5.0"
       },
@@ -5297,6 +5461,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/connect-common/-/connect-common-0.5.1.tgz",
       "integrity": "sha512-wdpVCwdylBh4SBO5Ys40tB/d59UlfjmxgBHDkkLgaR+JcqkthCfiw5VlUrV9wu65lquejAZhA5KQL4mUUUhCow==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
       "dependencies": {
         "@trezor/env-utils": "1.5.0",
         "@trezor/type-utils": "1.2.0",
@@ -5311,6 +5476,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/env-utils/-/env-utils-1.5.0.tgz",
       "integrity": "sha512-u1TN7dMQ5Qhpbae08Z4JJmI9fQrbbJ4yj8eIAsuzMQn6vb+Sg9vbntl+IDsZ1G9WeI73uHTLu1wWMmAgiujH8w==",
       "license": "See LICENSE.md in repo root",
+      "peer": true,
       "dependencies": {
         "ua-parser-js": "^2.0.4"
       },
@@ -5494,6 +5660,7 @@
       "resolved": "https://registry.npmjs.org/@solana-program/compute-budget/-/compute-budget-0.8.0.tgz",
       "integrity": "sha512-qPKxdxaEsFxebZ4K5RPuy7VQIm/tfJLa1+Nlt3KNA8EYQkz9Xm8htdoEaXVrer9kpgzzp9R3I3Bh6omwCM06tQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@solana/kit": "^2.1.0"
       }
@@ -5503,6 +5670,7 @@
       "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.7.0.tgz",
       "integrity": "sha512-FKTBsKHpvHHNc1ATRm7SlC5nF/VdJtOSjldhcyfMN9R7xo712Mo2jHIzvBgn8zQO5Kg0DcWuKB7268Kv1ocicw==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@solana/kit": "^2.1.0"
       }
@@ -5512,6 +5680,7 @@
       "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.5.1.tgz",
       "integrity": "sha512-bJvynW5q9SFuVOZ5vqGVkmaPGA0MCC+m9jgJj1nk5m20I389/ms69ASnhWGoOPNcie7S9OwBX0gTj2fiyWpfag==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@solana/kit": "^2.1.0"
       }
@@ -5521,6 +5690,7 @@
       "resolved": "https://registry.npmjs.org/@solana-program/token-2022/-/token-2022-0.4.2.tgz",
       "integrity": "sha512-zIpR5t4s9qEU3hZKupzIBxJ6nUV5/UVyIT400tu9vT1HMs5JHxaTTsb5GUhYjiiTvNwU0MQavbwc4Dl29L0Xvw==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@solana/kit": "^2.1.0",
         "@solana/sysvars": "^2.1.0"
@@ -5531,6 +5701,7 @@
       "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.3.0.tgz",
       "integrity": "sha512-QgQTj404Z6PXNOyzaOpSzjgMOuGwG8vC66jSDB+3zHaRcEPRVRd2sVSrd1U6sHtnV3aiaS6YyDuPQMheg4K2jw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "2.3.0",
         "@solana/codecs-core": "2.3.0",
@@ -5551,6 +5722,7 @@
       "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.3.0.tgz",
       "integrity": "sha512-ypTNkY2ZaRFpHLnHAgaW8a83N0/WoqdFvCqf4CQmnMdFsZSdC7qOwcbd7YzdaQn9dy+P2hybewzB+KP7LutxGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/assertions": "2.3.0",
         "@solana/codecs-core": "2.3.0",
@@ -5570,6 +5742,7 @@
       "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.3.0.tgz",
       "integrity": "sha512-Ekoet3khNg3XFLN7MIz8W31wPQISpKUGDGTylLptI+JjCDWx3PIa88xjEMqFo02WJ8sBj2NLV64Xg1sBcsHjZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0"
       },
@@ -5585,6 +5758,7 @@
       "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.3.0.tgz",
       "integrity": "sha512-JVqGPkzoeyU262hJGdH64kNLH0M+Oew2CIPOa/9tR3++q2pEd4jU2Rxdfye9sd0Ce3XJrR5AIa8ZfbyQXzjh+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "2.3.0",
         "@solana/codecs-data-structures": "2.3.0",
@@ -5604,6 +5778,7 @@
       "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
       "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0"
       },
@@ -5619,6 +5794,7 @@
       "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.3.0.tgz",
       "integrity": "sha512-qvU5LE5DqEdYMYgELRHv+HMOx73sSoV1ZZkwIrclwUmwTbTaH8QAJURBj0RhQ/zCne7VuLLOZFFGv6jGigWhSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "2.3.0",
         "@solana/codecs-numbers": "2.3.0",
@@ -5636,6 +5812,7 @@
       "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
       "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "2.3.0",
         "@solana/errors": "2.3.0"
@@ -5652,6 +5829,7 @@
       "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.3.0.tgz",
       "integrity": "sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "2.3.0",
         "@solana/codecs-numbers": "2.3.0",
@@ -5670,6 +5848,7 @@
       "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
       "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^5.4.1",
         "commander": "^14.0.0"
@@ -5689,6 +5868,7 @@
       "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.3.0.tgz",
       "integrity": "sha512-KfJPrMEieUg6D3hfQACoPy0ukrAV8Kio883llt/8chPEG3FVTX9z/Zuf4O01a15xZmBbmQ7toil2Dp0sxMJSxw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -5701,6 +5881,7 @@
       "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.3.0.tgz",
       "integrity": "sha512-AgsPh3W3tE+nK3eEw/W9qiSfTGwLYEvl0rWaxHht/lRcuDVwfKRzeSa5G79eioWFFqr+pTtoCr3D3OLkwKz02Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -5713,6 +5894,7 @@
       "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.3.0.tgz",
       "integrity": "sha512-PLMsmaIKu7hEAzyElrk2T7JJx4D+9eRwebhFZpy2PXziNSmFF929eRHKUsKqBFM3cYR1Yy3m6roBZfA+bGE/oQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "2.3.0",
         "@solana/errors": "2.3.0"
@@ -5729,6 +5911,7 @@
       "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.3.0.tgz",
       "integrity": "sha512-ZVVdga79pNH+2pVcm6fr2sWz9HTwfopDVhYb0Lh3dh+WBmJjwkabXEIHey2rUES7NjFa/G7sV8lrUn/v8LDCCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/assertions": "2.3.0",
         "@solana/codecs-core": "2.3.0",
@@ -5781,6 +5964,7 @@
       "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-2.3.0.tgz",
       "integrity": "sha512-uKlMnlP4PWW5UTXlhKM8lcgIaNj8dvd8xO4Y9l+FVvh9RvW2TO0GwUO6JCo7JBzCB0PSqRJdWWaQ8pu1Ti/OkA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -5793,6 +5977,7 @@
       "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.3.0.tgz",
       "integrity": "sha512-PPnnZBRCWWoZQ11exPxf//DRzN2C6AoFsDI/u2AsQfYih434/7Kp4XLpfOMT/XESi+gdBMFNNfbES5zg3wAIkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/codecs-core": "2.3.0",
         "@solana/codecs-data-structures": "2.3.0",
@@ -5812,6 +5997,7 @@
       "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.3.0.tgz",
       "integrity": "sha512-UXKujV71VCI5uPs+cFdwxybtHZAIZyQkqDiDnmK+DawtOO9mBn4Nimdb/6RjR2CXT78mzO9ZCZ3qfyX+ydcB7w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "2.3.0",
         "@solana/errors": "2.3.0"
@@ -5828,6 +6014,7 @@
       "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.3.0.tgz",
       "integrity": "sha512-GjVgutZKXVuojd9rWy1PuLnfcRfqsaCm7InCiZc8bqmJpoghlyluweNc7ml9Y5yQn1P2IOyzh9+p/77vIyNybQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -5840,6 +6027,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.3.0.tgz",
       "integrity": "sha512-ZWN76iNQAOCpYC7yKfb3UNLIMZf603JckLKOOLTHuy9MZnTN8XV6uwvDFhf42XvhglgUjGCEnbUqWtxQ9pa/pQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0",
         "@solana/fast-stable-stringify": "2.3.0",
@@ -5863,6 +6051,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.3.0.tgz",
       "integrity": "sha512-UUdiRfWoyYhJL9PPvFeJr4aJ554ob2jXcpn4vKmRVn9ire0sCbpQKYx6K8eEKHZWXKrDW8IDspgTl0gT/aJWVg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "2.3.0",
         "@solana/codecs-core": "2.3.0",
@@ -5888,6 +6077,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.3.0.tgz",
       "integrity": "sha512-B5pHzyEIbBJf9KHej+zdr5ZNAdSvu7WLU2lOUPh81KHdHQs6dEb310LGxcpCc7HVE8IEdO20AbckewDiAN6OCg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -5900,6 +6090,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.3.0.tgz",
       "integrity": "sha512-fA2LMX4BMixCrNB2n6T83AvjZ3oUQTu7qyPLyt8gHQaoEAXs8k6GZmu6iYcr+FboQCjUmRPgMaABbcr9j2J9Sw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0",
         "@solana/rpc-spec-types": "2.3.0"
@@ -5916,6 +6107,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.3.0.tgz",
       "integrity": "sha512-xQsb65lahjr8Wc9dMtP7xa0ZmDS8dOE2ncYjlvfyw/h4mpdXTUdrSMi6RtFwX33/rGuztQ7Hwaid5xLNSLvsFQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.0"
       },
@@ -5928,6 +6120,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.3.0.tgz",
       "integrity": "sha512-Uyr10nZKGVzvCOqwCZgwYrzuoDyUdwtgQRefh13pXIrdo4wYjVmoLykH49Omt6abwStB0a4UL5gX9V4mFdDJZg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0",
         "@solana/fast-stable-stringify": "2.3.0",
@@ -5953,6 +6146,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.3.0.tgz",
       "integrity": "sha512-9mCjVbum2Hg9KGX3LKsrI5Xs0KX390lS+Z8qB80bxhar6MJPugqIPH8uRgLhCW9GN3JprAfjRNl7our8CPvsPQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "2.3.0",
         "@solana/keys": "2.3.0",
@@ -5974,6 +6168,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-2.3.0.tgz",
       "integrity": "sha512-2oL6ceFwejIgeWzbNiUHI2tZZnaOxNTSerszcin7wYQwijxtpVgUHiuItM/Y70DQmH9sKhmikQp+dqeGalaJxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0",
         "@solana/functional": "2.3.0",
@@ -5993,6 +6188,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.3.0.tgz",
       "integrity": "sha512-rdmVcl4PvNKQeA2l8DorIeALCgJEMSu7U8AXJS1PICeb2lQuMeaR+6cs/iowjvIB0lMVjYN2sFf6Q3dJPu6wWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0",
         "@solana/promises": "2.3.0",
@@ -6011,6 +6207,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.3.0.tgz",
       "integrity": "sha512-UuHYK3XEpo9nMXdjyGKkPCOr7WsZsxs7zLYDO1A5ELH3P3JoehvrDegYRAGzBS2VKsfApZ86ZpJToP0K3PhmMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0",
         "@solana/functional": "2.3.0",
@@ -6030,6 +6227,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.3.0.tgz",
       "integrity": "sha512-HFKydmxGw8nAF5N+S0NLnPBDCe5oMDtI2RAmW8DMqP4U3Zxt2XWhvV1SNkAldT5tF0U1vP+is6fHxyhk4xqEvg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0",
         "@solana/rpc-spec": "2.3.0",
@@ -6048,6 +6246,7 @@
       "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.3.0.tgz",
       "integrity": "sha512-O09YX2hED2QUyGxrMOxQ9GzH1LlEwwZWu69QbL4oYmIf6P5dzEEHcqRY6L1LsDVqc/dzAdEs/E1FaPrcIaIIPw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "2.3.0",
         "@solana/codecs-core": "2.3.0",
@@ -6068,6 +6267,7 @@
       "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.3.0.tgz",
       "integrity": "sha512-OSv6fGr/MFRx6J+ZChQMRqKNPGGmdjkqarKkRzkwmv7v8quWsIRnJT5EV8tBy3LI4DLO/A8vKiNSPzvm1TdaiQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "2.3.0",
         "@solana/codecs-core": "2.3.0",
@@ -6090,6 +6290,7 @@
       "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-2.3.0.tgz",
       "integrity": "sha512-DkgohEDbMkdTWiKAoatY02Njr56WXx9e/dKKfmne8/Ad6/2llUIrax78nCdlvZW9quXMaXPTxZvdQqo9N669Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/errors": "2.3.0"
       },
@@ -6124,6 +6325,7 @@
       "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.3.0.tgz",
       "integrity": "sha512-UiEuiHCfAAZEKdfne/XljFNJbsKAe701UQHKXEInYzIgBjRbvaeYZlBmkkqtxwcasgBTOmEaEKT44J14N9VZDw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "2.3.0",
         "@solana/codecs-strings": "2.3.0",
@@ -6148,6 +6350,7 @@
       "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.3.0.tgz",
       "integrity": "sha512-bgqvWuy3MqKS5JdNLH649q+ngiyOu5rGS3DizSnWwYUd76RxZl1kN6CoqHSrrMzFMvis6sck/yPGG3wqrMlAww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "2.3.0",
         "@solana/codecs-core": "2.3.0",
@@ -6171,6 +6374,7 @@
       "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.3.0.tgz",
       "integrity": "sha512-LnTvdi8QnrQtuEZor5Msje61sDpPstTVwKg4y81tNxDhiyomjuvnSNLAq6QsB9gIxUqbNzPZgOG9IU4I4/Uaug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/addresses": "2.3.0",
         "@solana/codecs-core": "2.3.0",
@@ -6197,6 +6401,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/env-utils/-/env-utils-1.5.0.tgz",
       "integrity": "sha512-u1TN7dMQ5Qhpbae08Z4JJmI9fQrbbJ4yj8eIAsuzMQn6vb+Sg9vbntl+IDsZ1G9WeI73uHTLu1wWMmAgiujH8w==",
       "license": "See LICENSE.md in repo root",
+      "peer": true,
       "dependencies": {
         "ua-parser-js": "^2.0.4"
       },
@@ -6223,6 +6428,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -6234,13 +6440,15 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.29.0.tgz",
       "integrity": "sha512-vamA8dGlzMwhpyYpQp9d8vka3o4D/yn5I7ez7Or+msDA4bZ8Uh+Zy91WvWf3I73gDAkFha9JcYRqm2li0Npfgg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@trezor/crypto-utils": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@trezor/crypto-utils/-/crypto-utils-1.2.0.tgz",
       "integrity": "sha512-9i1NrfW1IE6JO910ut7xrx4u5LxE++GETbpJhWLj4P5xpuGDDSDLEn/MXaYisls2DpE897aOrGPaa1qyt8V6tw==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
       "peerDependencies": {
         "tslib": "^2.6.2"
       }
@@ -6250,6 +6458,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/device-authenticity/-/device-authenticity-1.1.2.tgz",
       "integrity": "sha512-313uSXYR4XKDv3CjtCpgHA+yEe9xxqN7EFl/D68FEn70SPsuWI0+2zUvjPPh6TIOh/EcLv7hCO/QTHUAGd7ZWQ==",
       "license": "See LICENSE.md in repo root",
+      "peer": true,
       "dependencies": {
         "@noble/curves": "^2.0.1",
         "@trezor/crypto-utils": "1.2.0",
@@ -6263,6 +6472,7 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.3.0.tgz",
       "integrity": "sha512-v7cY+4oWYPQszRj6ZFGzTVL7uP2TaLo1xMhWHzYC5wj0ZhOXQ5x+sBre8rF3hi8cAoi0bh1qXoovoOkdFtvqEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "2.3.0"
       },
@@ -6278,6 +6488,7 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
       "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -6290,6 +6501,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.5.2.tgz",
       "integrity": "sha512-zViaL1jKue8DUTVEDg0C/lMipqNMd/Z3kr29/+MeZOoupjaXIQ2Lqp3WAMe8hvNTKKX8aNQH9JrbapJ6w9FMXw==",
       "license": "See LICENSE.md in repo root",
+      "peer": true,
       "dependencies": {
         "@trezor/schema-utils": "1.4.0",
         "long": "5.2.5",
@@ -6305,6 +6517,7 @@
       "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -6327,13 +6540,15 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@trezor/device-utils/-/device-utils-1.2.0.tgz",
       "integrity": "sha512-Aqp7pIooFTx21zRUtTI6i1AS4d9Lrx7cclvksh2nJQF9WJvbzuCXshEGkLoOsHwhQrCl3IXfbGuMdA12yDenPA==",
-      "license": "See LICENSE.md in repo root"
+      "license": "See LICENSE.md in repo root",
+      "peer": true
     },
     "node_modules/@trezor/protobuf": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.5.3.tgz",
       "integrity": "sha512-ZYQtapkT2NaiVrAgb91Zprnk3uhl2Wca0bsnJcWgE7vwzqKegjrSorRnkZLqLTKTbCaT6sgkCYtM2hPl4Hqw5Q==",
       "license": "See LICENSE.md in repo root",
+      "peer": true,
       "dependencies": {
         "@trezor/schema-utils": "1.4.0",
         "long": "5.2.5",
@@ -6348,6 +6563,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/protocol/-/protocol-1.3.1.tgz",
       "integrity": "sha512-uNJ83n38+BM+AJKsWza1ocvQ206d6NXJQ8/g+DelPLTj5c37Rj6hFiY5Nb5zgM7DBnq6T8Aa2K8t4TVCzHT1qg==",
       "license": "See LICENSE.md in repo root",
+      "peer": true,
       "peerDependencies": {
         "tslib": "^2.6.2"
       }
@@ -6357,6 +6573,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/schema-utils/-/schema-utils-1.4.0.tgz",
       "integrity": "sha512-K7upSeh7VDrORaIC4KAxYVW93XNlohmUnH5if/5GKYmTdQSRp1nBkO6Jm+Z4hzIthdnz/1aLgnbeN3bDxWLRxA==",
       "license": "See LICENSE.md in repo root",
+      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.33.7",
         "ts-mixer": "^6.0.3"
@@ -6370,6 +6587,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/transport/-/transport-1.6.3.tgz",
       "integrity": "sha512-GEi9KfiJsBgT/MCGNDIn9RDeXceLaAPjJT/GCayirXaCr3KnlpZCs6LGYkrjqapxiBm73nxM+BctKBKhpUl2cQ==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
       "dependencies": {
         "@trezor/protobuf": "1.5.3",
         "@trezor/protocol": "1.3.1",
@@ -6386,13 +6604,15 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@trezor/type-utils/-/type-utils-1.2.0.tgz",
       "integrity": "sha512-+E2QntxkyQuYfQQyl8RvT01tq2i5Dp/LFUOXuizF+KVOqsZBjBY43j5hewcCO3+MokD7deDiPyekbUEN5/iVlw==",
-      "license": "See LICENSE.md in repo root"
+      "license": "See LICENSE.md in repo root",
+      "peer": true
     },
     "node_modules/@trezor/utils": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-9.5.0.tgz",
       "integrity": "sha512-kdyMyDbxzvOZmwBNvTjAK+C/kzyOz8T4oUbFvq+KaXn5mBFf1uf8rq5X2HkxgdYRPArtHS3PxLKsfkNCdhCYtQ==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
       "dependencies": {
         "bignumber.js": "^9.3.1"
       },
@@ -6405,6 +6625,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/utxo-lib/-/utxo-lib-2.5.0.tgz",
       "integrity": "sha512-Fa2cZh0037oX6AHNLfpFIj65UR/OoX0ZJTocFuQASe77/1PjZHysf6BvvGfmzuFToKfrAQ+DM/1Sx+P/vnyNmA==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
       "dependencies": {
         "@trezor/utils": "9.5.0",
         "bech32": "^2.0.0",
@@ -6433,6 +6654,7 @@
       "resolved": "https://registry.npmjs.org/@trezor/websocket-client/-/websocket-client-1.3.0.tgz",
       "integrity": "sha512-9KQSaVc3NtmM6rFFj1e+9bM0C5mVKVidbnxlfzuBJu7G2YMRdIdLPcAXhvmRZjs40uzDuBeApK+p547kODz2ug==",
       "license": "SEE LICENSE IN LICENSE.md",
+      "peer": true,
       "dependencies": {
         "@trezor/utils": "9.5.0",
         "ws": "^8.18.0"
@@ -6569,7 +6791,6 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6606,13 +6827,15 @@
       "version": "1.0.14",
       "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.14.tgz",
       "integrity": "sha512-Qu3Nn6JFuF4+sHKYl+IcX9vYiI40ogleXzFFSxoE1W94rG98o/kXs8uJ0QSfFzuwBCZWlGfUGpPkgwuuX4PchA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/web": {
       "version": "0.0.197",
       "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.197.tgz",
       "integrity": "sha512-V4sOroWDADFx9dLodWpKm298NOJ1VJ6zoDVgaP+WBb/utWxqQ6gnMzd9lvVDAr/F3ibiKaxH9i45eS0gQPSTaQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@types/ws": {
       "version": "7.4.7",
@@ -6668,7 +6891,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -7448,6 +7670,21 @@
         "ws": "^7.5.1"
       }
     },
+    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.13",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
@@ -8048,6 +8285,7 @@
       "resolved": "https://registry.npmjs.org/@xrplf/isomorphic/-/isomorphic-1.0.2.tgz",
       "integrity": "sha512-ncZUdMXr6VlSXtdoiDi0jTH+gBrgGxwVeEidhoegII3PmyErbQsyj6e+j7acmR4LW/lvBkPkzb9QzRfJH0n3rA==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "^2.0.1",
         "eventemitter3": "5.0.1",
@@ -8062,6 +8300,7 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
       "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -8073,13 +8312,15 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@xrplf/isomorphic/node_modules/ws": {
       "version": "8.21.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
       "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -8101,6 +8342,7 @@
       "resolved": "https://registry.npmjs.org/@xrplf/secret-numbers/-/secret-numbers-2.0.0.tgz",
       "integrity": "sha512-z3AOibRTE9E8MbjgzxqMpG1RNaBhQ1jnfhNCa1cGf2reZUJzPMYs4TggQTc7j8+0WyV3cr7y/U8Oz99SXIkN5Q==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@xrplf/isomorphic": "^1.0.1",
         "ripple-keypairs": "^2.0.0"
@@ -8133,7 +8375,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8156,6 +8397,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -8408,6 +8650,7 @@
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
@@ -8418,7 +8661,8 @@
       "version": "4.12.5",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
       "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
@@ -8482,7 +8726,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
       "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
@@ -8525,6 +8768,7 @@
       "integrity": "sha512-F/SD2du8keuYSb4xipnGz5j2E6yhNdHA8ZVxtHae6h2uOrpBIjjbhXvjzKZbr5XUOzqBzh/i8GVFycj2DlFQIA==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "bare-module-resolve": "^1.10.0",
         "bare-semver": "^1.0.0"
@@ -8544,6 +8788,7 @@
       "integrity": "sha512-xcfgg2u7HqgJiBmah71O9vvdFAgHCvkqC/WSC2O7Bbgosoc1eC/BWe/6IDJ4OsfKlkxuvC/TDWXC+oH5yeW8mA==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "bare-semver": "^1.0.0"
       },
@@ -8561,7 +8806,8 @@
       "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.1.0.tgz",
       "integrity": "sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==",
       "license": "Apache-2.0",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/base-x": {
       "version": "5.0.1",
@@ -8602,13 +8848,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
       "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/big-integer": {
       "version": "1.6.36",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
       "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==",
       "license": "Unlicense",
+      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -8640,6 +8888,7 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -8654,13 +8903,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bip66/-/bip66-2.0.0.tgz",
       "integrity": "sha512-kBG+hSpgvZBrkIm9dt5T1Hd/7xGCPEX2npoxAWZfsK1FvjgaxySEh2WizjyIstWXriKo9K9uJ4u0OnsyLDUPXQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/bitcoin-ops": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
       "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/blake-hash": {
       "version": "2.0.0",
@@ -8668,6 +8919,7 @@
       "integrity": "sha512-Igj8YowDu1PRkRsxZA7NVkdFNxH5rKv5cpLxQ0CVXSIA77pVYwCPRQJ2sMew/oneUpfuYRyjG6r8SmmmnbZb1w==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-addon-api": "^3.0.0",
         "node-gyp-build": "^4.2.2",
@@ -8730,6 +8982,7 @@
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -8744,6 +8997,7 @@
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "browserify-aes": "^1.0.4",
         "browserify-des": "^1.0.0",
@@ -8755,6 +9009,7 @@
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cipher-base": "^1.0.1",
         "des.js": "^1.0.0",
@@ -8767,6 +9022,7 @@
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
       "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bn.js": "^5.2.1",
         "randombytes": "^2.1.0",
@@ -8781,6 +9037,7 @@
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.6.tgz",
       "integrity": "sha512-sd+Q65fjlWCYWtZKXiKfrUc8d+4jtp/8f0W2NkwzLtoW4bI6UDnWusLWIurHnmurW0XShIRxpwiOX4EoPtXUAg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "bn.js": "^5.2.3",
         "browserify-rsa": "^4.1.1",
@@ -8800,13 +9057,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/browserify-sign/node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -8821,13 +9080,15 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/browserify-sign/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -8836,7 +9097,8 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/bs58": {
       "version": "6.0.0",
@@ -8852,6 +9114,7 @@
       "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
       "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bs58": "^6.0.0"
@@ -8885,13 +9148,29 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -8984,6 +9263,7 @@
       "resolved": "https://registry.npmjs.org/cashaddrjs/-/cashaddrjs-0.4.4.tgz",
       "integrity": "sha512-xZkuWdNOh0uq/mxJIng6vYWfTowZLd9F4GMAlp2DwFHlcCqCm91NtuAc47RuV4L7r4PYcY5p6Cr2OKNb4hnkWA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "big-integer": "1.6.36"
       }
@@ -8993,6 +9273,7 @@
       "resolved": "https://registry.npmjs.org/cbor/-/cbor-10.0.12.tgz",
       "integrity": "sha512-exQDevYd7ZQLP4moMQcZkKCVZsXLAtUSflObr3xTh4xzFIv/xBCdvCd6L259kQOUP2kcTC0jvC6PpZIf/WmRXA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nofilter": "^3.0.2"
       },
@@ -9046,6 +9327,7 @@
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
       "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.4",
         "safe-buffer": "^5.2.1",
@@ -9137,13 +9419,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
       "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.5.3"
@@ -9153,13 +9437,15 @@
       "version": "4.12.5",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
       "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -9173,6 +9459,7 @@
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -9187,6 +9474,7 @@
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
       "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-fetch": "^2.7.0"
       }
@@ -9229,6 +9517,7 @@
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "browserify-cipher": "^1.0.0",
         "browserify-sign": "^4.0.0",
@@ -9250,8 +9539,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -9566,6 +9854,7 @@
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
       "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
@@ -9601,7 +9890,8 @@
           "url": "https://paypal.me/faisalman"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -9617,6 +9907,7 @@
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bn.js": "^4.1.0",
         "miller-rabin": "^4.0.0",
@@ -9627,7 +9918,8 @@
       "version": "4.12.5",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
       "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
@@ -9676,6 +9968,7 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -9705,8 +9998,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -9996,7 +10288,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10170,7 +10461,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -10437,6 +10727,7 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
       "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -10455,6 +10746,7 @@
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -10464,7 +10756,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/eyes": {
       "version": "0.1.8",
@@ -10585,7 +10878,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -10761,6 +11055,7 @@
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-property": "^1.0.2"
       }
@@ -10770,6 +11065,7 @@
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha512-TuOwZWgJ2VAMEGJvAyPWvpqxSANF0LDpmyHauMjFYzaACvn+QTT/AZomvPCzVBV7yDN3OmwHQ5OvHaeLKre3JQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-property": "^1.0.0"
       }
@@ -11032,6 +11328,7 @@
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
       "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.4",
         "readable-stream": "^2.3.8",
@@ -11046,13 +11343,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/hash-base/node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -11067,13 +11366,15 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/hash-base/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -11082,7 +11383,8 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/hash.js": {
       "version": "1.1.7",
@@ -11128,6 +11430,7 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
       "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -11144,6 +11447,7 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -11152,7 +11456,8 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -11229,7 +11534,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -11272,7 +11576,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.1.1.tgz",
       "integrity": "sha512-xp/v0/im2q7n7ISFJXcYsr/aVsUdZKPUZS1uYtoM9I9Cfmm5YuAi7SQts2TrEXwAKIE0wyn3KxJbo35goJgvwQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -11303,6 +11608,7 @@
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
       "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -11552,13 +11858,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz",
       "integrity": "sha512-jxc8cBcOWbNK2i2aTkCZP6i7wkHF1bqKFrwEHuN5Jtg5BSaZHUZQ/JTOJwoV41YvHnOaRyWWh72T/KvfNz9DJg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-my-json-valid": {
       "version": "2.20.6",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.6.tgz",
       "integrity": "sha512-1JQwulVNjx8UqkPE/bqDaxtH4PXCe/2VRh/y3p99heOV87HG4Id5/VfDswd+YiAfHcRTfDlWgISycnHuhZq1aw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "generate-function": "^2.0.0",
         "generate-object-property": "^1.1.0",
@@ -11611,7 +11919,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -11692,7 +12001,8 @@
           "url": "https://paypal.me/faisalman"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-string": {
       "version": "1.1.1",
@@ -11883,6 +12193,21 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
+    "node_modules/jayson/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.13",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
@@ -11994,6 +12319,7 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
       "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12019,6 +12345,7 @@
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -12030,6 +12357,7 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -12404,7 +12732,8 @@
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.5.tgz",
       "integrity": "sha512-e0r9YBBgNCq1D1o5Dp8FMH0N5hsFtXDBiVa0qoJPHpakvZkmDKPRoGffZJII/XsHvj9An9blm+cRJ01yQqU+Dw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -12423,7 +12752,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
       "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lru-cache": {
       "version": "11.5.2",
@@ -12479,6 +12809,7 @@
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -12514,6 +12845,7 @@
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
@@ -12526,7 +12858,8 @@
       "version": "4.12.5",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
       "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -12627,7 +12960,8 @@
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
       "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -12675,6 +13009,7 @@
       "resolved": "https://registry.npmjs.org/near-abi/-/near-abi-0.2.0.tgz",
       "integrity": "sha512-kCwSf/3fraPU2zENK18sh+kKG4uKbEUEQdyWQkmW8ZofmLarObIz2+zAYjA1teDZLeMvEQew3UysnPDXgjneaA==",
       "license": "(MIT AND Apache-2.0)",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }
@@ -12684,6 +13019,7 @@
       "resolved": "https://registry.npmjs.org/near-api-js/-/near-api-js-5.1.1.tgz",
       "integrity": "sha512-h23BGSKxNv8ph+zU6snicstsVK1/CTXsQz4LuGGwoRE24Hj424nSe4+/1tzoiC285Ljf60kPAqRCmsfv9etF2g==",
       "license": "(MIT AND Apache-2.0)",
+      "peer": true,
       "dependencies": {
         "@near-js/accounts": "1.4.1",
         "@near-js/crypto": "1.4.2",
@@ -12708,13 +13044,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/borsh/-/borsh-1.0.0.tgz",
       "integrity": "sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/near-api-js/node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -12735,7 +13073,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
       "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "15.5.9",
         "@swc/helpers": "0.5.15",
@@ -12824,7 +13161,8 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -12874,6 +13212,7 @@
       "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
       "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.19"
       }
@@ -13162,6 +13501,7 @@
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
       "integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "asn1.js": "^4.10.1",
         "browserify-aes": "^1.2.0",
@@ -13204,6 +13544,7 @@
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.6.tgz",
       "integrity": "sha512-BT6eelPB1EyGHo8pC0o9Bl6k6SYVhKO1jEbd3lcTrtr7XHdjP8BW1YpfCV3G9Kwkxgattk+S5q2/RvuttCsS1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
@@ -13332,7 +13673,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
       "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -13360,7 +13700,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/process-warning": {
       "version": "5.1.0",
@@ -13396,6 +13737,7 @@
       "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -13434,6 +13776,7 @@
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
       "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bn.js": "^4.1.0",
         "browserify-rsa": "^4.0.0",
@@ -13447,7 +13790,8 @@
       "version": "4.12.5",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
       "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -13464,6 +13808,7 @@
       "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
       "integrity": "sha512-hw7rcYTJRAl4olM8Owe8x0fBuJJ+WGbMhQuLWOXEMN3PxPCKQHRkhfL+XG0+iXUmSHjkMmb3Ba55Mt21cZc9kQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bitcoin-ops": "^1.3.0"
       }
@@ -13542,6 +13887,7 @@
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
@@ -13552,7 +13898,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13562,7 +13907,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -13575,7 +13919,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -13623,15 +13966,13 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -13665,6 +14006,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -13730,8 +14072,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -13792,6 +14133,7 @@
       "integrity": "sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "bare-addon-resolve": "^1.3.0"
       },
@@ -13877,6 +14219,7 @@
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
       "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hash-base": "^3.1.2",
         "inherits": "^2.0.4"
@@ -13890,6 +14233,7 @@
       "resolved": "https://registry.npmjs.org/ripple-address-codec/-/ripple-address-codec-5.0.1.tgz",
       "integrity": "sha512-JQHLKuVJV8lv9Qobmn4aUM2Dpv9WRRLKnNWfM8tN02fAbUtG8mUPsu9q9UYX8P76G4qzytEc5ZKMp/3JggNYmw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@scure/base": "^2.0.0",
         "@xrplf/isomorphic": "^1.0.2"
@@ -13903,6 +14247,7 @@
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.3.0.tgz",
       "integrity": "sha512-NsG6Y03tY6R5BUis4FdVtHVkur0U6FOzskgs9ZXNl78CUc9fkZ78HmENUle1nSOkCasDmbubmWD9qwB7mm4PZA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -13912,6 +14257,7 @@
       "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-2.9.0.tgz",
       "integrity": "sha512-DOv4CPwm2B5mjAJNHE4tfes7tIqefi85iun8BskS7/i1PvLIwVydHIbTV5hbQ7eT69Zg4K5dtO1CzfuvQVAYvQ==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@xrplf/isomorphic": "^1.0.2",
         "bignumber.js": "^10.0.2",
@@ -13925,13 +14271,15 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-10.0.2.tgz",
       "integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ripple-keypairs": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ripple-keypairs/-/ripple-keypairs-2.0.0.tgz",
       "integrity": "sha512-b5rfL2EZiffmklqZk1W+dvSy97v3V/C7936WxCCgDynaGPp7GE6R2XO7EU9O2LlM/z95rj870IylYnOQs+1Rag==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@noble/curves": "^1.0.0",
         "@xrplf/isomorphic": "^1.0.0",
@@ -14200,13 +14548,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/sha.js": {
       "version": "2.4.12",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
       "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
       "license": "(MIT AND BSD-3-Clause)",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.4",
         "safe-buffer": "^5.2.1",
@@ -14241,7 +14591,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -14390,6 +14739,7 @@
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -14440,6 +14790,7 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
       "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
@@ -14454,6 +14805,7 @@
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -14469,6 +14821,7 @@
       "integrity": "sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "require-addon": "^1.1.0"
       }
@@ -14522,6 +14875,7 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -14545,6 +14899,7 @@
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
       "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "~2.0.4",
         "readable-stream": "^3.5.0"
@@ -14570,6 +14925,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -14853,6 +15209,7 @@
       "integrity": "sha512-eb+F6NabSnjbLwNoC+2o5ItbmP1kg7HliWue71JgLegQt6A5mTN8YbvTLCazdlg6e5SV6A+r8OGvZYskdlmhqQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bindings": "^1.3.0",
         "bn.js": "^4.11.8",
@@ -14868,7 +15225,8 @@
       "version": "4.12.5",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
       "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -14911,7 +15269,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14924,6 +15281,7 @@
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
       "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isarray": "^2.0.5",
         "safe-buffer": "^5.2.1",
@@ -14951,6 +15309,7 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -14959,7 +15318,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -15003,8 +15363,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
@@ -15112,14 +15471,14 @@
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15146,7 +15505,8 @@
           "url": "https://paypal.me/faisalman"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ua-parser-js": {
       "version": "2.0.10",
@@ -15167,6 +15527,7 @@
         }
       ],
       "license": "AGPL-3.0-or-later",
+      "peer": true,
       "dependencies": {
         "detect-europe-js": "^0.1.2",
         "is-standalone-pwa": "^0.1.1",
@@ -15202,6 +15563,7 @@
       "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.8.tgz",
       "integrity": "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -15391,7 +15753,8 @@
       "version": "1.19.11",
       "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
       "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/usb": {
       "version": "2.18.0",
@@ -15399,6 +15762,7 @@
       "integrity": "sha512-klAJPUTaSxRvTgrIh7om6UTrgRxdzioD+rJc/MaoiN8+OGdqRzai39tR00asnoCesPNikItWB9zBZoo0pJsWaA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/w3c-web-usb": "^1.0.6",
         "node-addon-api": "^8.0.0",
@@ -15413,6 +15777,7 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
       "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18 || ^20 || >= 21"
       }
@@ -15422,7 +15787,6 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -15445,7 +15809,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -15492,6 +15857,7 @@
       "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-2.0.0.tgz",
       "integrity": "sha512-6QZbU/rHO2ZQYpWFDALCDSRsXbAs1VOEmXAxtbtjLtKuMJ/FQ8YbhfxlaiKv5nklci0M6lZtlZyxo9Q+qNnyog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "uint8array-tools": "^0.0.8"
       }
@@ -15784,6 +16150,7 @@
       "resolved": "https://registry.npmjs.org/wif/-/wif-5.0.0.tgz",
       "integrity": "sha512-iFzrC/9ne740qFbNjTZ2FciSRJlHIXoxqk/Y5EnE08QOXu1WjJyCCswwDTYbohAOEnlCtLaAAQBhyaLRFh2hMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bs58check": "^4.0.0"
       }
@@ -15817,7 +16184,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -15847,6 +16213,7 @@
       "resolved": "https://registry.npmjs.org/xrpl/-/xrpl-4.4.3.tgz",
       "integrity": "sha512-vi2OjuNkiaP8nv1j+nqHp8GZwwEjO6Y8+j/OuVMg6M4LwXEwyHdIj33dlg7cyY1Lw5+jb9HqFOQvABhaywVbTQ==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@scure/bip32": "^1.3.1",
         "@scure/bip39": "^1.2.1",
@@ -15868,6 +16235,7 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.4"
       }
@@ -15983,7 +16351,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "test": "echo \"No tests configured\" && exit 0"
   },
   "dependencies": {
+    "@creit.tech/stellar-wallets-kit": "^2.5.0",
     "@dnd-kit/core": "^6.3.1",
     "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-query": "^5.90.19",


### PR DESCRIPTION
## Summary

Replaces the mock `StellarCheckout` (`setTimeout`, regex address check, not routed anywhere) with a working non-custodial payment flow, per ADR 0001 and building on the endpoints from #313/#314.

- **Wallet-connect** via Stellar Wallets Kit (Freighter / Albedo / LOBSTR) instead of manual address entry — the connected wallet is now the sole source of the signing address, so there's no free-text field to validate.
- **Trustline detection + one-time setup flow** for USDC before a payment attempt can fail on `op_no_trust`, plus explicit handling for a wallet that has never been funded/created on the network.
- **Real endpoint wiring**: `initiate` → wallet signs → `submit-signed` → poll `GET /payments/stellar/:paymentId` for confirmation. No mocked steps remain.
- **Error taxonomy**: a specific, actionable message per `PaymentErrorCode`, plus wallet-side failures (user rejected the signature, wallet unavailable).
- **New route**: `frontend/app/checkout/[orderId]` — the URL a table's QR code (ADR 0002) would actually encode (`?token=<checkout token>`), so the checkout component is reachable end-to-end instead of only importable in isolation.

### Backend additions this required

- `StellarService.getAccountTrustlines` / `buildTrustlineTransaction`, exposed via three new `PaymentsController` endpoints: `GET account/:publicKey/trustlines`, `POST account/trustline`, `POST account/trustline/submit`.
- `DinerOrdersController` (`GET orders/:orderId/checkout-summary`), gated by the existing `DinerCheckoutGuard` — there was previously no diner-facing way to fetch an order's real items/total to render checkout with (every `OrdersController` route is staff-gated).

### Scope decisions (also called out inline in code comments)

- **No asset dropdown.** An order's settlement asset is fixed at creation time (`order.entity.ts`'s `currency` column), so payment always uses `order.currency`, not a diner-selectable asset. The old mock's dropdown would have let a diner "pay" in an asset the order was never priced in.
- **No custodial/guided onboarding path.** ADR 0001 explicitly rejected the hybrid model for v1 — only the wallet-connect path is in scope.
- **Status polling, not a diner-facing WebSocket subscription.** `PaymentsGateway` requires a staff JWT with `restaurantId` to join its room; a diner's checkout token can't authenticate there. Documenting this now rather than wiring a socket connection that would silently never authenticate.
- **USDC checkout is disabled unless `NEXT_PUBLIC_USDC_ASSET_ISSUER` is configured**, rather than hardcoding a testnet/mainnet issuer address I can't verify is correct. XLM checkout is unaffected (native asset, no issuer needed).
- **BITE is out of scope** — the backend's `InitiatePaymentDto` only allows `XLM`/`USDC`; there's no issuer or backend support for BITE anywhere yet.

## Test plan

- [x] Backend: `stellar.service.spec.ts` extended with tests for `getAccountTrustlines` (funded/unfunded/native+non-native balances) and `buildTrustlineTransaction`.
- [x] Backend: new `payments.controller.spec.ts` covering the three new endpoints, including public-key validation rejecting malformed input before any Horizon call.
- [x] Backend: new `diner-orders.controller.spec.ts` covering the order-scoping check and the decimal-string→number coercion for `total`.
- [ ] CI: backend lint/build/test, frontend lint/build/test (`npm ci` picks up the new `@creit.tech/stellar-wallets-kit` dependency via the updated lockfile).
- [ ] Manual: connect a real wallet (Freighter) on testnet and complete a payment end-to-end — flagged in the issue as required for the "no mocked steps" acceptance criterion; I don't have a way to drive a browser wallet extension from here, so this still needs a human pass before merge.

Closes #315