### PR TITLE
Payment: End-to-end settlement — multi-party distribution, security hardening, demo flow

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -41,3 +41,19 @@ STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 # Diner checkout token TTL, in seconds (see docs/adr/0002-diner-checkout-authentication.md)
 CHECKOUT_TOKEN_TTL_SECONDS=900
 
+# Platform fee (see docs/adr/0004-platform-fee-and-loyalty-distribution.md)
+# Optional — no fee is collected unless BOTH are set. Rides as a second
+# payment operation in the same diner-signed transaction; no separate key.
+PLATFORM_FEE_STELLAR_ADDRESS=
+PLATFORM_FEE_BPS=0
+
+# Loyalty payouts (see docs/adr/0004-platform-fee-and-loyalty-distribution.md)
+# LoyaltyPayoutService fails fast at boot if LOYALTY_ISSUER_SECRET is
+# missing or invalid. This is a platform-operated Stellar account used
+# ONLY to send the platform's own loyalty asset to diners after a
+# confirmed payment — never diner or restaurant funds/keys.
+LOYALTY_ISSUER_SECRET=
+LOYALTY_ASSET_CODE=BITE
+# 1000 = 10%, matching the README's worked example (loyaltyRate = 0.10)
+LOYALTY_RATE_BPS=1000
+

--- a/backend/src/modules/payments/loyalty-payout-state-machine.spec.ts
+++ b/backend/src/modules/payments/loyalty-payout-state-machine.spec.ts
@@ -1,0 +1,66 @@
+import { UnprocessableEntityException } from '@nestjs/common';
+import {
+  assertValidPayoutTransition,
+  canTransitionPayout,
+} from './loyalty-payout-state-machine';
+import { LoyaltyPayoutStatus } from './loyalty-payout.entity';
+
+describe('loyalty payout state machine', () => {
+  const ALL_STATUSES = Object.values(LoyaltyPayoutStatus);
+
+  const VALID_TRANSITIONS: [LoyaltyPayoutStatus, LoyaltyPayoutStatus][] = [
+    [LoyaltyPayoutStatus.PENDING, LoyaltyPayoutStatus.SUBMITTED],
+    [LoyaltyPayoutStatus.PENDING, LoyaltyPayoutStatus.FAILED],
+    [LoyaltyPayoutStatus.SUBMITTED, LoyaltyPayoutStatus.CONFIRMED],
+    [LoyaltyPayoutStatus.SUBMITTED, LoyaltyPayoutStatus.FAILED],
+    [LoyaltyPayoutStatus.FAILED, LoyaltyPayoutStatus.SUBMITTED],
+  ];
+
+  it.each(VALID_TRANSITIONS)('allows %s -> %s', (from, to) => {
+    expect(canTransitionPayout(from, to)).toBe(true);
+    expect(() => assertValidPayoutTransition(from, to)).not.toThrow();
+  });
+
+  const validSet = new Set(
+    VALID_TRANSITIONS.map(([from, to]) => `${from}->${to}`),
+  );
+
+  const illegalTransitions = ALL_STATUSES.flatMap((from) =>
+    ALL_STATUSES.filter((to) => !validSet.has(`${from}->${to}`)).map(
+      (to): [LoyaltyPayoutStatus, LoyaltyPayoutStatus] => [from, to],
+    ),
+  );
+
+  it.each(illegalTransitions)('rejects %s -> %s', (from, to) => {
+    expect(canTransitionPayout(from, to)).toBe(false);
+    expect(() => assertValidPayoutTransition(from, to)).toThrow(
+      UnprocessableEntityException,
+    );
+  });
+
+  it('never allows confirmed to be reached directly from pending', () => {
+    expect(
+      canTransitionPayout(
+        LoyaltyPayoutStatus.PENDING,
+        LoyaltyPayoutStatus.CONFIRMED,
+      ),
+    ).toBe(false);
+  });
+
+  it('allows a failed payout to be retried via a fresh submission, unlike Payment', () => {
+    expect(
+      canTransitionPayout(
+        LoyaltyPayoutStatus.FAILED,
+        LoyaltyPayoutStatus.SUBMITTED,
+      ),
+    ).toBe(true);
+  });
+
+  it('has no outgoing transitions from the only true terminal status (confirmed)', () => {
+    for (const to of ALL_STATUSES) {
+      expect(canTransitionPayout(LoyaltyPayoutStatus.CONFIRMED, to)).toBe(
+        false,
+      );
+    }
+  });
+});

--- a/backend/src/modules/payments/loyalty-payout-state-machine.ts
+++ b/backend/src/modules/payments/loyalty-payout-state-machine.ts
@@ -1,0 +1,49 @@
+// backend/src/modules/payments/loyalty-payout-state-machine.ts
+import { UnprocessableEntityException } from '@nestjs/common';
+import { LoyaltyPayoutStatus } from './loyalty-payout.entity';
+
+/**
+ * The single source of truth for legal LoyaltyPayout status transitions
+ * (issue #316 / ADR 0004): `pending -> submitted -> confirmed | failed`,
+ * with two differences from Payment (ADR 0003):
+ *  - `pending -> failed` directly is also legal — building/signing the
+ *    payout transaction itself can fail before anything is ever submitted
+ *    (e.g. a malformed destination), and that must still be recordable as
+ *    FAILED rather than stuck PENDING forever.
+ *  - `failed -> submitted` is legal — a failed payout is retried
+ *    automatically by LoyaltyPayoutService with a fresh submission, rather
+ *    than being a dead end the diner has to re-trigger.
+ * `confirmed` is reachable only from `submitted`, and only after
+ * independently verifying the transaction against Horizon by hash — same
+ * discipline as Payment's CONFIRMED.
+ */
+const ALLOWED_TRANSITIONS: Record<LoyaltyPayoutStatus, LoyaltyPayoutStatus[]> = {
+  [LoyaltyPayoutStatus.PENDING]: [
+    LoyaltyPayoutStatus.SUBMITTED,
+    LoyaltyPayoutStatus.FAILED,
+  ],
+  [LoyaltyPayoutStatus.SUBMITTED]: [
+    LoyaltyPayoutStatus.CONFIRMED,
+    LoyaltyPayoutStatus.FAILED,
+  ],
+  [LoyaltyPayoutStatus.FAILED]: [LoyaltyPayoutStatus.SUBMITTED],
+  [LoyaltyPayoutStatus.CONFIRMED]: [],
+};
+
+export function canTransitionPayout(
+  from: LoyaltyPayoutStatus,
+  to: LoyaltyPayoutStatus,
+): boolean {
+  return ALLOWED_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+export function assertValidPayoutTransition(
+  from: LoyaltyPayoutStatus,
+  to: LoyaltyPayoutStatus,
+): void {
+  if (!canTransitionPayout(from, to)) {
+    throw new UnprocessableEntityException(
+      `Illegal loyalty payout status transition: ${from} -> ${to}`,
+    );
+  }
+}

--- a/backend/src/modules/payments/loyalty-payout.entity.ts
+++ b/backend/src/modules/payments/loyalty-payout.entity.ts
@@ -1,0 +1,86 @@
+// backend/src/modules/payments/loyalty-payout.entity.ts
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Payment } from './payment.entity';
+
+export enum LoyaltyPayoutStatus {
+  PENDING = 'pending',
+  SUBMITTED = 'submitted',
+  CONFIRMED = 'confirmed',
+  FAILED = 'failed',
+}
+
+// One loyalty payout per confirmed payment — a platform-signed transaction
+// distinct from the (diner-signed) primary payment, so it needs its own
+// idempotent, independently-retryable lifecycle (issue #316 / ADR 0004).
+@Entity('loyalty_payouts')
+export class LoyaltyPayout {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  // Last line of defense against double-issuing loyalty for the same
+  // payment — enforced at the DB constraint level, mirroring
+  // Payment.idempotencyKey's pattern, not just checked in application code.
+  @Column({ type: 'uuid', unique: true })
+  paymentId: string;
+
+  @ManyToOne(() => Payment, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'paymentId' })
+  payment: Payment;
+
+  @Column({ type: 'uuid' })
+  orderId: string;
+
+  // The diner's own wallet — same account that signed the primary payment
+  // (Payment.sourceAccount). The platform sends TO this account; the diner
+  // never signs anything for their own payout.
+  @Column({ type: 'varchar', length: 56 })
+  destinationAccount: string;
+
+  @Column({ type: 'varchar', length: 12 })
+  assetCode: string;
+
+  @Column({ type: 'varchar', length: 56 })
+  assetIssuer: string;
+
+  @Column({ type: 'decimal', precision: 20, scale: 7 })
+  amount: number;
+
+  @Column({
+    type: 'enum',
+    enum: LoyaltyPayoutStatus,
+    default: LoyaltyPayoutStatus.PENDING,
+  })
+  status: LoyaltyPayoutStatus;
+
+  @Column({ type: 'varchar', length: 64, nullable: true })
+  stellarTxHash: string | null;
+
+  @Column({ type: 'varchar', length: 64, nullable: true })
+  failureReason: string | null;
+
+  // How many submission attempts so far — drives the retry job's backoff,
+  // so a payout stuck for a real reason (e.g. diner has no trustline for
+  // the loyalty asset) doesn't hammer Horizon every tick.
+  @Column({ type: 'int', default: 0 })
+  attemptCount: number;
+
+  @Column({ type: 'timestamp', nullable: true })
+  lastAttemptAt: Date | null;
+
+  @Column({ type: 'timestamp', nullable: true })
+  confirmedAt: Date | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/modules/payments/loyalty-payout.service.spec.ts
+++ b/backend/src/modules/payments/loyalty-payout.service.spec.ts
@@ -1,0 +1,465 @@
+import { Logger } from '@nestjs/common';
+import { QueryFailedError } from 'typeorm';
+import { Keypair, NotFoundError } from '@stellar/stellar-sdk';
+import { LoyaltyPayoutService } from './loyalty-payout.service';
+import { LoyaltyPayoutStatus } from './loyalty-payout.entity';
+import { Payment } from './payment.entity';
+
+type MockRepository = {
+  create: jest.Mock;
+  save: jest.Mock;
+  findOne: jest.Mock;
+  find: jest.Mock;
+};
+
+function makeRepository(): MockRepository {
+  return {
+    create: jest.fn((data) => ({ ...data })),
+    save: jest.fn(async (entity) => entity),
+    findOne: jest.fn(),
+    find: jest.fn(),
+  };
+}
+
+function makeUniqueViolation(): QueryFailedError {
+  return new QueryFailedError('INSERT INTO loyalty_payouts...', [], {
+    name: 'error',
+    message: 'duplicate key value violates unique constraint',
+    code: '23505',
+  } as any);
+}
+
+const issuerKeypair = Keypair.random();
+const dinerKeypair = Keypair.random();
+
+function makeConfig(overrides: Record<string, string | undefined> = {}) {
+  const values: Record<string, string | undefined> = {
+    LOYALTY_ISSUER_SECRET: issuerKeypair.secret(),
+    LOYALTY_ASSET_CODE: 'BITE',
+    LOYALTY_RATE_BPS: '1000',
+    ...overrides,
+  };
+  return { get: jest.fn((key: string, fallback?: string) => values[key] ?? fallback) };
+}
+
+function makePayment(overrides: Partial<Payment> = {}): Payment {
+  return {
+    id: 'payment-1',
+    orderId: 'order-1',
+    sourceAccount: dinerKeypair.publicKey(),
+    destinationAccount: 'GDEST...',
+    asset: 'XLM',
+    amount: 10,
+    status: 'confirmed' as any,
+    stellarTxHash: 'tx-hash-1',
+    ...overrides,
+  } as Payment;
+}
+
+function makePayout(overrides: Partial<any> = {}) {
+  return {
+    id: 'payout-1',
+    paymentId: 'payment-1',
+    orderId: 'order-1',
+    destinationAccount: dinerKeypair.publicKey(),
+    assetCode: 'BITE',
+    assetIssuer: issuerKeypair.publicKey(),
+    amount: 1,
+    status: LoyaltyPayoutStatus.PENDING,
+    stellarTxHash: null,
+    failureReason: null,
+    attemptCount: 0,
+    lastAttemptAt: null,
+    confirmedAt: null,
+    ...overrides,
+  };
+}
+
+describe('LoyaltyPayoutService (issue #316 / ADR 0004)', () => {
+  let payoutRepository: MockRepository;
+  let orderRepository: MockRepository;
+  let stellarService: {
+    buildPaymentTransaction: jest.Mock;
+    signTransactionWithKeypair: jest.Mock;
+    computeTransactionHash: jest.Mock;
+    submitTransaction: jest.Mock;
+    fetchTransaction: jest.Mock;
+  };
+  let sequenceAllocator: { allocate: jest.Mock; invalidate: jest.Mock };
+  let paymentsGateway: { emitLoyaltyPayoutStatusChanged: jest.Mock };
+  let service: LoyaltyPayoutService;
+
+  beforeEach(() => {
+    payoutRepository = makeRepository();
+    orderRepository = makeRepository();
+    orderRepository.findOne.mockResolvedValue({
+      id: 'order-1',
+      restaurantId: 'restaurant-1',
+    });
+    stellarService = {
+      buildPaymentTransaction: jest.fn().mockResolvedValue('unsigned-xdr'),
+      signTransactionWithKeypair: jest.fn().mockReturnValue('signed-xdr'),
+      computeTransactionHash: jest.fn().mockReturnValue('computed-hash'),
+      submitTransaction: jest.fn(),
+      fetchTransaction: jest.fn(),
+    };
+    sequenceAllocator = {
+      allocate: jest.fn().mockResolvedValue('101'),
+      invalidate: jest.fn(),
+    };
+    paymentsGateway = { emitLoyaltyPayoutStatusChanged: jest.fn() };
+
+    service = new LoyaltyPayoutService(
+      payoutRepository as any,
+      orderRepository as any,
+      stellarService as any,
+      sequenceAllocator as any,
+      makeConfig() as any,
+      paymentsGateway as any,
+    );
+    service.onModuleInit();
+  });
+
+  describe('onModuleInit — secret handling', () => {
+    it('throws when LOYALTY_ISSUER_SECRET is missing', () => {
+      const s = new LoyaltyPayoutService(
+        payoutRepository as any,
+        orderRepository as any,
+        stellarService as any,
+        sequenceAllocator as any,
+        makeConfig({ LOYALTY_ISSUER_SECRET: undefined }) as any,
+        paymentsGateway as any,
+      );
+      expect(() => s.onModuleInit()).toThrow(/LOYALTY_ISSUER_SECRET is not configured/);
+    });
+
+    it('throws a generic message for an invalid secret, never echoing the raw input', () => {
+      const badSecret = 'SNOT-A-REAL-STELLAR-SECRET-KEY-AT-ALL-XYZ';
+      const s = new LoyaltyPayoutService(
+        payoutRepository as any,
+        orderRepository as any,
+        stellarService as any,
+        sequenceAllocator as any,
+        makeConfig({ LOYALTY_ISSUER_SECRET: badSecret }) as any,
+        paymentsGateway as any,
+      );
+
+      let caught: Error | undefined;
+      try {
+        s.onModuleInit();
+      } catch (e) {
+        caught = e as Error;
+      }
+
+      expect(caught).toBeDefined();
+      expect(caught!.message).toMatch(/not a valid Stellar secret key/);
+      expect(caught!.message).not.toContain(badSecret);
+    });
+
+    it('never logs the secret anywhere, on success or failure', () => {
+      const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+      const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+      const errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+
+      const secret = issuerKeypair.secret();
+      const s = new LoyaltyPayoutService(
+        payoutRepository as any,
+        orderRepository as any,
+        stellarService as any,
+        sequenceAllocator as any,
+        makeConfig({ LOYALTY_ISSUER_SECRET: secret }) as any,
+        paymentsGateway as any,
+      );
+      s.onModuleInit();
+
+      const allCalls = [...logSpy.mock.calls, ...warnSpy.mock.calls, ...errorSpy.mock.calls];
+      for (const call of allCalls) {
+        for (const arg of call) {
+          expect(String(arg)).not.toContain(secret);
+        }
+      }
+
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('createForConfirmedPayment', () => {
+    it('creates a PENDING payout for the README-documented 10% default rate', async () => {
+      const payment = makePayment({ amount: 10 });
+
+      await service.createForConfirmedPayment(payment);
+
+      expect(payoutRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paymentId: 'payment-1',
+          orderId: 'order-1',
+          destinationAccount: dinerKeypair.publicKey(),
+          assetCode: 'BITE',
+          assetIssuer: issuerKeypair.publicKey(),
+          amount: 1,
+          status: LoyaltyPayoutStatus.PENDING,
+        }),
+      );
+    });
+
+    it('creates nothing when the computed loyalty amount is zero', async () => {
+      const s = new LoyaltyPayoutService(
+        payoutRepository as any,
+        orderRepository as any,
+        stellarService as any,
+        sequenceAllocator as any,
+        makeConfig({ LOYALTY_RATE_BPS: '0' }) as any,
+        paymentsGateway as any,
+      );
+      s.onModuleInit();
+
+      await s.createForConfirmedPayment(makePayment({ amount: 10 }));
+
+      expect(payoutRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent: a duplicate paymentId (DB unique violation) is treated as already-created, not an error', async () => {
+      payoutRepository.save.mockRejectedValueOnce(makeUniqueViolation());
+
+      await expect(
+        service.createForConfirmedPayment(makePayment()),
+      ).resolves.toBeUndefined();
+    });
+
+    it('rethrows a save failure that is not the idempotency unique-violation', async () => {
+      payoutRepository.save.mockRejectedValueOnce(new Error('connection reset'));
+
+      await expect(
+        service.createForConfirmedPayment(makePayment()),
+      ).rejects.toThrow('connection reset');
+    });
+  });
+
+  describe('processPending — submission', () => {
+    it('builds, signs with the issuer key, computes the hash, and submits a PENDING payout', async () => {
+      payoutRepository.find
+        .mockResolvedValueOnce([makePayout()]) // PENDING batch
+        .mockResolvedValueOnce([]) // FAILED batch
+        .mockResolvedValueOnce([]); // SUBMITTED batch (confirm pass)
+      stellarService.submitTransaction.mockResolvedValueOnce({
+        hash: 'computed-hash',
+        successful: true,
+      });
+
+      const summary = await service.processPending();
+
+      expect(sequenceAllocator.allocate).toHaveBeenCalledWith(
+        issuerKeypair.publicKey(),
+      );
+      expect(stellarService.buildPaymentTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceAccount: issuerKeypair.publicKey(),
+          destinationAccount: dinerKeypair.publicKey(),
+          assetCode: 'BITE',
+          assetIssuer: issuerKeypair.publicKey(),
+          amount: '1.0000000',
+        }),
+      );
+      expect(stellarService.signTransactionWithKeypair).toHaveBeenCalledWith(
+        'unsigned-xdr',
+        expect.objectContaining({ publicKey: expect.any(Function) }),
+      );
+      expect(payoutRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: LoyaltyPayoutStatus.SUBMITTED,
+          stellarTxHash: 'computed-hash',
+          attemptCount: 1,
+        }),
+      );
+      expect(summary.submitted).toBe(1);
+    });
+
+    it('marks a payout FAILED on a definitive Horizon rejection', async () => {
+      payoutRepository.find
+        .mockResolvedValueOnce([makePayout()])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+      stellarService.submitTransaction.mockRejectedValueOnce({
+        response: {
+          data: {
+            extras: {
+              result_codes: { transaction: 'tx_failed', operations: ['op_no_destination'] },
+            },
+          },
+        },
+      });
+
+      const summary = await service.processPending();
+
+      expect(summary.failed).toBe(1);
+      expect(payoutRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: LoyaltyPayoutStatus.FAILED,
+          attemptCount: 2, // 1 for the SUBMITTED transition, 1 for FAILED
+        }),
+      );
+    });
+
+    it('leaves a payout SUBMITTED on an ambiguous submit error, not FAILED', async () => {
+      payoutRepository.find
+        .mockResolvedValueOnce([makePayout()])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+      stellarService.submitTransaction.mockRejectedValueOnce(
+        new Error('socket hang up'),
+      );
+
+      const summary = await service.processPending();
+
+      expect(summary.submitted).toBe(1);
+      expect(summary.failed).toBe(0);
+      expect(payoutRepository.save).toHaveBeenLastCalledWith(
+        expect.objectContaining({ status: LoyaltyPayoutStatus.SUBMITTED }),
+      );
+    });
+
+    it('does not retry a FAILED payout before its backoff window elapses', async () => {
+      const recentlyFailed = makePayout({
+        status: LoyaltyPayoutStatus.FAILED,
+        attemptCount: 1,
+        lastAttemptAt: new Date(),
+      });
+      payoutRepository.find
+        .mockResolvedValueOnce([]) // PENDING
+        .mockResolvedValueOnce([recentlyFailed]) // FAILED
+        .mockResolvedValueOnce([]); // SUBMITTED
+
+      await service.processPending();
+
+      expect(stellarService.buildPaymentTransaction).not.toHaveBeenCalled();
+    });
+
+    it('records a second failure on a retried FAILED payout that fails again before reaching SUBMITTED, without crashing the batch', async () => {
+      const longAgoFailed = makePayout({
+        status: LoyaltyPayoutStatus.FAILED,
+        attemptCount: 1,
+        lastAttemptAt: new Date(Date.now() - 10 * 60 * 1000),
+      });
+      payoutRepository.find
+        .mockResolvedValueOnce([]) // PENDING
+        .mockResolvedValueOnce([longAgoFailed]) // FAILED, eligible
+        .mockResolvedValueOnce([]); // SUBMITTED
+      // Fails before ever reaching SUBMITTED — e.g. sequence allocation itself errors.
+      sequenceAllocator.allocate.mockRejectedValueOnce(new Error('allocator unavailable'));
+
+      const summary = await service.processPending();
+
+      expect(summary.failed).toBe(1);
+      expect(payoutRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: LoyaltyPayoutStatus.FAILED,
+          attemptCount: 2,
+          failureReason: 'allocator unavailable',
+        }),
+      );
+    });
+
+    it('retries a FAILED payout once its backoff window has elapsed, and it can then succeed — idempotent recovery (issue #316 acceptance criteria)', async () => {
+      const longAgoFailed = makePayout({
+        status: LoyaltyPayoutStatus.FAILED,
+        attemptCount: 1,
+        lastAttemptAt: new Date(Date.now() - 10 * 60 * 1000), // 10 min ago
+      });
+      payoutRepository.find
+        .mockResolvedValueOnce([]) // PENDING
+        .mockResolvedValueOnce([longAgoFailed]) // FAILED, eligible
+        .mockResolvedValueOnce([]); // SUBMITTED
+      stellarService.submitTransaction.mockResolvedValueOnce({
+        hash: 'computed-hash',
+        successful: true,
+      });
+
+      const summary = await service.processPending();
+
+      expect(stellarService.buildPaymentTransaction).toHaveBeenCalledTimes(1);
+      expect(summary.submitted).toBe(1);
+      expect(payoutRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: LoyaltyPayoutStatus.SUBMITTED, attemptCount: 2 }),
+      );
+      // Still exactly the one payout row — retried, not duplicated.
+      expect(payoutRepository.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('processPending — confirmation', () => {
+    it('confirms a SUBMITTED payout once Horizon reports it successful', async () => {
+      const submittedPayout = makePayout({
+        status: LoyaltyPayoutStatus.SUBMITTED,
+        stellarTxHash: 'tx-hash-1',
+      });
+      payoutRepository.find
+        .mockResolvedValueOnce([]) // PENDING
+        .mockResolvedValueOnce([]) // FAILED
+        .mockResolvedValueOnce([submittedPayout]); // SUBMITTED
+      stellarService.fetchTransaction.mockResolvedValueOnce({
+        hash: 'tx-hash-1',
+        successful: true,
+      });
+
+      const summary = await service.processPending();
+
+      expect(summary.confirmed).toBe(1);
+      expect(payoutRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: LoyaltyPayoutStatus.CONFIRMED }),
+      );
+      expect(paymentsGateway.emitLoyaltyPayoutStatusChanged).toHaveBeenCalledWith(
+        'restaurant-1',
+        expect.objectContaining({
+          payoutId: 'payout-1',
+          status: LoyaltyPayoutStatus.CONFIRMED,
+        }),
+      );
+    });
+
+    it('leaves a SUBMITTED payout unresolved when Horizon has no record yet (propagation delay)', async () => {
+      const submittedPayout = makePayout({
+        status: LoyaltyPayoutStatus.SUBMITTED,
+        stellarTxHash: 'tx-hash-1',
+      });
+      payoutRepository.find
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([submittedPayout]);
+      stellarService.fetchTransaction.mockRejectedValueOnce(
+        new NotFoundError('not found', {}),
+      );
+
+      const summary = await service.processPending();
+
+      expect(summary.stillPending).toBe(1);
+      expect(payoutRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('marks a SUBMITTED payout FAILED when Horizon reports it unsuccessful', async () => {
+      const submittedPayout = makePayout({
+        status: LoyaltyPayoutStatus.SUBMITTED,
+        stellarTxHash: 'tx-hash-1',
+      });
+      payoutRepository.find
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([submittedPayout]);
+      stellarService.fetchTransaction.mockResolvedValueOnce({
+        hash: 'tx-hash-1',
+        successful: false,
+      });
+
+      const summary = await service.processPending();
+
+      expect(summary.failed).toBe(1);
+      expect(payoutRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: LoyaltyPayoutStatus.FAILED,
+          failureReason: 'SUBMISSION_FAILED',
+        }),
+      );
+    });
+  });
+});

--- a/backend/src/modules/payments/loyalty-payout.service.ts
+++ b/backend/src/modules/payments/loyalty-payout.service.ts
@@ -1,0 +1,365 @@
+// backend/src/modules/payments/loyalty-payout.service.ts
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { QueryFailedError, Repository } from 'typeorm';
+import { Keypair, NotFoundError } from '@stellar/stellar-sdk';
+import { Order } from '../orders/order.entity';
+import { Payment } from './payment.entity';
+import { LoyaltyPayout, LoyaltyPayoutStatus } from './loyalty-payout.entity';
+import { StellarService } from './stellar.service';
+import { SequenceAllocator } from './sequence-allocator.service';
+import { PaymentsGateway } from './payments.gateway';
+import { assertValidPayoutTransition } from './loyalty-payout-state-machine';
+import {
+  isDefinitiveHorizonRejection,
+  mapHorizonSubmissionError,
+} from './errors/horizon-error-mapper';
+
+// Postgres unique_violation — see PaymentsService.createPayment for the
+// identical pattern this mirrors.
+const POSTGRES_UNIQUE_VIOLATION = '23505';
+
+const BASE_RETRY_BACKOFF_SECONDS = 30;
+const MAX_RETRY_BACKOFF_SECONDS = 300;
+
+export interface LoyaltyPayoutSummary {
+  submitted: number;
+  confirmed: number;
+  failed: number;
+  stillPending: number;
+}
+
+/**
+ * Issues loyalty tokens to a diner after their payment confirms — a
+ * platform-signed transaction (issue #316 / ADR 0004), genuinely separate
+ * from and independently-retryable from the (diner-signed, possibly
+ * fee-split) primary payment. Two jobs on its own schedule, mirroring
+ * PaymentReconciliationService's shape:
+ *
+ *  1. Submit every PENDING (or backed-off FAILED) payout: build, sign with
+ *     the platform's loyalty issuer key, and send to Horizon.
+ *  2. For every SUBMITTED payout, independently verify against Horizon by
+ *     hash — the only path allowed to set CONFIRMED.
+ */
+@Injectable()
+export class LoyaltyPayoutService implements OnModuleInit {
+  private readonly logger = new Logger(LoyaltyPayoutService.name);
+  private issuerKeypair: Keypair;
+  private assetCode: string;
+  private rateBps: number;
+
+  constructor(
+    @InjectRepository(LoyaltyPayout)
+    private readonly payoutRepository: Repository<LoyaltyPayout>,
+    @InjectRepository(Order)
+    private readonly orderRepository: Repository<Order>,
+    private readonly stellarService: StellarService,
+    private readonly sequenceAllocator: SequenceAllocator,
+    private readonly configService: ConfigService,
+    private readonly paymentsGateway: PaymentsGateway,
+  ) {}
+
+  // Fail fast at boot, mirroring StellarService.onModuleInit (issue #312's
+  // pattern) — a missing/invalid loyalty issuer key should never surface
+  // only when the first order confirms.
+  onModuleInit(): void {
+    const secret = this.configService.get<string>('LOYALTY_ISSUER_SECRET');
+    if (!secret) {
+      throw new Error(
+        'LoyaltyPayoutService: LOYALTY_ISSUER_SECRET is not configured',
+      );
+    }
+
+    try {
+      this.issuerKeypair = Keypair.fromSecret(secret);
+    } catch {
+      // Deliberately a fresh message, never the caught error's own — some
+      // SDK versions can echo fragments of malformed input in their error
+      // text, and this secret must never appear anywhere in logs (issue
+      // #316 acceptance criteria: "no secret key material in logs").
+      throw new Error(
+        'LoyaltyPayoutService: LOYALTY_ISSUER_SECRET is not a valid Stellar secret key',
+      );
+    }
+
+    this.assetCode = this.configService.get<string>(
+      'LOYALTY_ASSET_CODE',
+      'BITE',
+    );
+    this.rateBps = Number(
+      this.configService.get<string>('LOYALTY_RATE_BPS', '1000'),
+    );
+
+    this.logger.log(
+      `Loyalty payout service ready (asset=${this.assetCode}, issuer=${this.issuerKeypair.publicKey()}, rateBps=${this.rateBps})`,
+    );
+  }
+
+  /**
+   * Computes the loyalty amount owed for a confirmed payment and persists
+   * a PENDING payout row — fast, no Horizon call, so it never adds latency
+   * to payment confirmation itself. Actual submission happens on this
+   * service's own scheduled tick.
+   *
+   * Idempotent: `paymentId` is unique at the DB level (mirrors
+   * PaymentsService.createPayment's race-handling), so calling this twice
+   * for the same payment — e.g. a defensive re-call, or two reconciliation
+   * ticks somehow overlapping — never creates a second payout.
+   */
+  async createForConfirmedPayment(payment: Payment): Promise<void> {
+    const amount = this.computeLoyaltyAmount(payment.amount);
+    if (amount <= 0) return;
+
+    const payout = this.payoutRepository.create({
+      paymentId: payment.id,
+      orderId: payment.orderId,
+      destinationAccount: payment.sourceAccount,
+      assetCode: this.assetCode,
+      assetIssuer: this.issuerKeypair.publicKey(),
+      amount,
+      status: LoyaltyPayoutStatus.PENDING,
+    });
+
+    try {
+      const saved = await this.payoutRepository.save(payout);
+      this.logger.log(
+        `Loyalty payout ${saved.id} created for payment ${payment.id} (order ${payment.orderId}): ${amount} ${this.assetCode}`,
+      );
+    } catch (error) {
+      if (this.isUniqueViolation(error)) {
+        // Already exists — not an error. Exactly one payout per payment,
+        // guaranteed by the paymentId unique constraint, not just this
+        // best-effort check.
+        return;
+      }
+      throw error;
+    }
+  }
+
+  computeLoyaltyAmount(paymentAmount: number | string): number {
+    const raw = (Number(paymentAmount) * this.rateBps) / 10_000;
+    return Math.round(raw * 1e7) / 1e7; // clamp to Stellar's 7-decimal precision
+  }
+
+  @Cron(CronExpression.EVERY_10_SECONDS)
+  async handleCron(): Promise<void> {
+    const summary = await this.processPending();
+    if (summary.submitted > 0 || summary.confirmed > 0 || summary.failed > 0) {
+      this.logger.log(`Loyalty payout pass: ${JSON.stringify(summary)}`);
+    }
+  }
+
+  async processPending(
+    now: Date = new Date(),
+  ): Promise<LoyaltyPayoutSummary> {
+    const summary: LoyaltyPayoutSummary = {
+      submitted: 0,
+      confirmed: 0,
+      failed: 0,
+      stillPending: 0,
+    };
+
+    await this.submitEligible(now, summary);
+    await this.confirmSubmitted(summary);
+
+    return summary;
+  }
+
+  private async submitEligible(
+    now: Date,
+    summary: LoyaltyPayoutSummary,
+  ): Promise<void> {
+    const pending = await this.payoutRepository.find({
+      where: { status: LoyaltyPayoutStatus.PENDING },
+    });
+    const failed = await this.payoutRepository.find({
+      where: { status: LoyaltyPayoutStatus.FAILED },
+    });
+    const eligible = [
+      ...pending,
+      ...failed.filter((payout) => this.isBackoffElapsed(payout, now)),
+    ];
+
+    for (const payout of eligible) {
+      await this.submitOne(payout, summary);
+    }
+  }
+
+  private isBackoffElapsed(payout: LoyaltyPayout, now: Date): boolean {
+    if (!payout.lastAttemptAt) return true;
+    const backoffSeconds = Math.min(
+      BASE_RETRY_BACKOFF_SECONDS * 2 ** payout.attemptCount,
+      MAX_RETRY_BACKOFF_SECONDS,
+    );
+    return (
+      now.getTime() - new Date(payout.lastAttemptAt).getTime() >=
+      backoffSeconds * 1000
+    );
+  }
+
+  private async submitOne(
+    payout: LoyaltyPayout,
+    summary: LoyaltyPayoutSummary,
+  ): Promise<void> {
+    const issuerPublicKey = this.issuerKeypair.publicKey();
+
+    try {
+      const sequence = await this.sequenceAllocator.allocate(issuerPublicKey);
+      const unsignedXdr = await this.stellarService.buildPaymentTransaction({
+        sourceAccount: issuerPublicKey,
+        destinationAccount: payout.destinationAccount,
+        assetCode: payout.assetCode,
+        assetIssuer: payout.assetIssuer,
+        amount: Number(payout.amount).toFixed(7),
+        memo: `loyalty:${payout.orderId}`.slice(0, 28),
+        sequenceOverride: sequence,
+      });
+      const signedXdr = this.stellarService.signTransactionWithKeypair(
+        unsignedXdr,
+        this.issuerKeypair,
+      );
+      const stellarTxHash =
+        this.stellarService.computeTransactionHash(signedXdr);
+
+      assertValidPayoutTransition(payout.status, LoyaltyPayoutStatus.SUBMITTED);
+      payout.status = LoyaltyPayoutStatus.SUBMITTED;
+      payout.stellarTxHash = stellarTxHash;
+      payout.attemptCount += 1;
+      payout.lastAttemptAt = new Date();
+      await this.payoutRepository.save(payout);
+
+      try {
+        await this.stellarService.submitTransaction(signedXdr);
+        summary.submitted++;
+      } catch (error) {
+        if (!isDefinitiveHorizonRejection(error)) {
+          // Ambiguous — same reasoning as PaymentsService.submitSigned:
+          // leave it SUBMITTED for the confirm pass to resolve by hash,
+          // rather than risk marking a possibly-successful payout FAILED.
+          this.logger.warn(
+            `Ambiguous submit error for loyalty payout ${payout.id} (tx ${stellarTxHash}); leaving SUBMITTED for reconciliation: ` +
+              (error instanceof Error ? error.message : String(error)),
+          );
+          summary.submitted++;
+          return;
+        }
+
+        const mapped = mapHorizonSubmissionError(error);
+        if (mapped.code === 'SEQUENCE_CONFLICT') {
+          this.sequenceAllocator.invalidate(issuerPublicKey);
+        }
+        await this.markFailed(payout, mapped.code, summary);
+      }
+    } catch (error) {
+      await this.markFailed(
+        payout,
+        error instanceof Error ? error.message : 'PAYOUT_BUILD_FAILED',
+        summary,
+      );
+    }
+  }
+
+  private async confirmSubmitted(
+    summary: LoyaltyPayoutSummary,
+  ): Promise<void> {
+    const submitted = await this.payoutRepository.find({
+      where: { status: LoyaltyPayoutStatus.SUBMITTED },
+    });
+
+    for (const payout of submitted) {
+      if (!payout.stellarTxHash) {
+        summary.stillPending++;
+        continue;
+      }
+
+      try {
+        const record = await this.stellarService.fetchTransaction(
+          payout.stellarTxHash,
+        );
+
+        if (record.successful) {
+          assertValidPayoutTransition(
+            payout.status,
+            LoyaltyPayoutStatus.CONFIRMED,
+          );
+          payout.status = LoyaltyPayoutStatus.CONFIRMED;
+          payout.confirmedAt = new Date();
+          const saved = await this.payoutRepository.save(payout);
+          this.logger.log(
+            `Loyalty payout ${saved.id} confirmed (order ${saved.orderId}, tx ${saved.stellarTxHash})`,
+          );
+          summary.confirmed++;
+          await this.emitStatusChanged(saved);
+        } else {
+          await this.markFailed(payout, 'SUBMISSION_FAILED', summary);
+        }
+      } catch (error) {
+        if (error instanceof NotFoundError) {
+          // Expected for a short window after submission — bounded
+          // retrying happens on the next scheduled tick, same as
+          // PaymentReconciliationService's propagation-delay handling.
+          summary.stillPending++;
+          continue;
+        }
+        this.logger.warn(
+          `Loyalty payout confirmation check failed for ${payout.id}: ` +
+            (error instanceof Error ? error.message : String(error)),
+        );
+        summary.stillPending++;
+      }
+    }
+  }
+
+  private async markFailed(
+    payout: LoyaltyPayout,
+    reason: string,
+    summary: LoyaltyPayoutSummary,
+  ): Promise<void> {
+    // A retried payout can fail again before ever reaching SUBMITTED
+    // (e.g. sequence allocation itself throws) — that's recording another
+    // failed attempt on an already-FAILED row, not a state transition, so
+    // the legality check only applies when actually crossing into FAILED
+    // from a different status (FAILED -> FAILED isn't a modeled edge in
+    // loyalty-payout-state-machine.ts, and shouldn't need to be).
+    if (payout.status !== LoyaltyPayoutStatus.FAILED) {
+      assertValidPayoutTransition(payout.status, LoyaltyPayoutStatus.FAILED);
+      payout.status = LoyaltyPayoutStatus.FAILED;
+    }
+    payout.failureReason = reason;
+    payout.attemptCount += 1;
+    payout.lastAttemptAt = new Date();
+    const saved = await this.payoutRepository.save(payout);
+    this.logger.warn(
+      `Loyalty payout ${saved.id} failed (order ${saved.orderId}, attempt ${saved.attemptCount}): ${reason}`,
+    );
+    summary.failed++;
+    await this.emitStatusChanged(saved);
+  }
+
+  private async emitStatusChanged(payout: LoyaltyPayout): Promise<void> {
+    const order = await this.orderRepository.findOne({
+      where: { id: payout.orderId },
+    });
+    if (!order) return;
+
+    this.paymentsGateway.emitLoyaltyPayoutStatusChanged(order.restaurantId, {
+      payoutId: payout.id,
+      paymentId: payout.paymentId,
+      orderId: payout.orderId,
+      status: payout.status,
+      stellarTxHash: payout.stellarTxHash,
+      failureReason: payout.failureReason,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  private isUniqueViolation(error: unknown): boolean {
+    return (
+      error instanceof QueryFailedError &&
+      (error as unknown as { code?: string }).code ===
+        POSTGRES_UNIQUE_VIOLATION
+    );
+  }
+}

--- a/backend/src/modules/payments/payment-reconciliation.service.spec.ts
+++ b/backend/src/modules/payments/payment-reconciliation.service.spec.ts
@@ -1,6 +1,7 @@
 import { NotFoundError } from '@stellar/stellar-sdk';
 import { PaymentReconciliationService } from './payment-reconciliation.service';
 import { Payment, PaymentStatus } from './payment.entity';
+import { OrderStatus } from '../orders/order.entity';
 
 type MockRepository = {
   find: jest.Mock;
@@ -42,6 +43,7 @@ describe('PaymentReconciliationService', () => {
   let orderRepository: MockRepository;
   let stellarService: { fetchTransaction: jest.Mock };
   let paymentsGateway: { emitPaymentStatusChanged: jest.Mock };
+  let loyaltyPayoutService: { createForConfirmedPayment: jest.Mock };
   let service: PaymentReconciliationService;
 
   beforeEach(() => {
@@ -49,10 +51,12 @@ describe('PaymentReconciliationService', () => {
     orderRepository = makeRepository();
     stellarService = { fetchTransaction: jest.fn() };
     paymentsGateway = { emitPaymentStatusChanged: jest.fn() };
+    loyaltyPayoutService = { createForConfirmedPayment: jest.fn() };
 
     orderRepository.findOne.mockResolvedValue({
       id: 'order-1',
       restaurantId: 'restaurant-1',
+      status: OrderStatus.PENDING,
     });
 
     service = new PaymentReconciliationService(
@@ -60,6 +64,7 @@ describe('PaymentReconciliationService', () => {
       orderRepository as any,
       stellarService as any,
       paymentsGateway as any,
+      loyaltyPayoutService as any,
     );
   });
 
@@ -160,6 +165,99 @@ describe('PaymentReconciliationService', () => {
 
       expect(secondSummary.confirmed).toBe(0);
       expect(stellarService.fetchTransaction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('reconcile — order-paid flip and loyalty payout trigger (issue #316)', () => {
+    it('flips the order from PENDING to CONFIRMED ("paid") once the payment confirms', async () => {
+      const payment = makePayment();
+      paymentRepository.find
+        .mockResolvedValueOnce([payment])
+        .mockResolvedValueOnce([]);
+      stellarService.fetchTransaction.mockResolvedValueOnce({
+        hash: 'tx-hash-1',
+        successful: true,
+      });
+
+      await service.reconcile();
+
+      expect(orderRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'order-1', status: OrderStatus.CONFIRMED }),
+      );
+    });
+
+    it('does not touch an order the kitchen has already moved past PENDING (idempotent re-run safety)', async () => {
+      orderRepository.findOne.mockResolvedValue({
+        id: 'order-1',
+        restaurantId: 'restaurant-1',
+        status: OrderStatus.PREPARING,
+      });
+      const payment = makePayment();
+      paymentRepository.find
+        .mockResolvedValueOnce([payment])
+        .mockResolvedValueOnce([]);
+      stellarService.fetchTransaction.mockResolvedValueOnce({
+        hash: 'tx-hash-1',
+        successful: true,
+      });
+
+      await service.reconcile();
+
+      expect(orderRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('creates a loyalty payout when a payment confirms', async () => {
+      const payment = makePayment();
+      paymentRepository.find
+        .mockResolvedValueOnce([payment])
+        .mockResolvedValueOnce([]);
+      stellarService.fetchTransaction.mockResolvedValueOnce({
+        hash: 'tx-hash-1',
+        successful: true,
+      });
+
+      await service.reconcile();
+
+      expect(loyaltyPayoutService.createForConfirmedPayment).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'payment-1', status: PaymentStatus.CONFIRMED }),
+      );
+    });
+
+    it('does not create a loyalty payout when a payment fails, only on confirmation', async () => {
+      const payment = makePayment();
+      paymentRepository.find
+        .mockResolvedValueOnce([payment])
+        .mockResolvedValueOnce([]);
+      stellarService.fetchTransaction.mockResolvedValueOnce({
+        hash: 'tx-hash-1',
+        successful: false,
+      });
+
+      await service.reconcile();
+
+      expect(loyaltyPayoutService.createForConfirmedPayment).not.toHaveBeenCalled();
+      expect(orderRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('does not let a loyalty payout creation failure roll back the already-saved CONFIRMED payment status', async () => {
+      loyaltyPayoutService.createForConfirmedPayment.mockRejectedValueOnce(
+        new Error('payout service unavailable'),
+      );
+      const payment = makePayment();
+      paymentRepository.find
+        .mockResolvedValueOnce([payment])
+        .mockResolvedValueOnce([]);
+      stellarService.fetchTransaction.mockResolvedValueOnce({
+        hash: 'tx-hash-1',
+        successful: true,
+      });
+
+      const summary = await service.reconcile();
+
+      expect(summary.confirmed).toBe(1);
+      expect(paymentRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ status: PaymentStatus.CONFIRMED }),
+      );
     });
   });
 

--- a/backend/src/modules/payments/payment-reconciliation.service.ts
+++ b/backend/src/modules/payments/payment-reconciliation.service.ts
@@ -4,10 +4,11 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { LessThan, Repository } from 'typeorm';
 import { NotFoundError } from '@stellar/stellar-sdk';
-import { Order } from '../orders/order.entity';
+import { Order, OrderStatus } from '../orders/order.entity';
 import { Payment, PaymentStatus } from './payment.entity';
 import { StellarService } from './stellar.service';
 import { PaymentsGateway } from './payments.gateway';
+import { LoyaltyPayoutService } from './loyalty-payout.service';
 import { assertValidTransition } from './payment-state-machine';
 
 export interface ReconciliationSummary {
@@ -53,6 +54,7 @@ export class PaymentReconciliationService {
     private readonly orderRepository: Repository<Order>,
     private readonly stellarService: StellarService,
     private readonly paymentsGateway: PaymentsGateway,
+    private readonly loyaltyPayoutService: LoyaltyPayoutService,
   ) {}
 
   @Cron(CronExpression.EVERY_10_SECONDS)
@@ -132,6 +134,23 @@ export class PaymentReconciliationService {
         `Payment ${saved.id} reconciled to ${saved.status} (tx ${payment.stellarTxHash})`,
       );
       await this.emitStatusChanged(saved);
+
+      if (saved.status === PaymentStatus.CONFIRMED) {
+        // Distinct, independently-retryable concerns from the payment
+        // itself (issue #316 / ADR 0004) — a hiccup in either must never
+        // roll back or block the payment's own CONFIRMED status, which is
+        // already durably saved above.
+        await this.markOrderPaid(saved.orderId);
+        try {
+          await this.loyaltyPayoutService.createForConfirmedPayment(saved);
+        } catch (error) {
+          this.logger.error(
+            `Failed to create loyalty payout for payment ${saved.id} (order ${saved.orderId}): ` +
+              (error instanceof Error ? error.message : String(error)),
+          );
+        }
+      }
+
       return saved;
     } catch (error) {
       if (error instanceof NotFoundError) {
@@ -191,6 +210,26 @@ export class PaymentReconciliationService {
       await this.emitStatusChanged(saved);
       summary.expired++;
     }
+  }
+
+  /**
+   * A confirmed payment flips its order from PENDING to CONFIRMED — "paid"
+   * (issue #316: the order-marked-paid step of the settlement flow). Only
+   * ever advances from PENDING: if staff already moved the order further
+   * (PREPARING, etc.) or it was somehow already CONFIRMED, reconciliation
+   * re-running this (idempotent by construction, since a Payment only
+   * reaches CONFIRMED once — see payment-state-machine.ts) must never
+   * clobber a status the kitchen workflow has since moved past.
+   */
+  private async markOrderPaid(orderId: string): Promise<void> {
+    const order = await this.orderRepository.findOne({
+      where: { id: orderId },
+    });
+    if (!order || order.status !== OrderStatus.PENDING) return;
+
+    order.status = OrderStatus.CONFIRMED;
+    await this.orderRepository.save(order);
+    this.logger.log(`Order ${orderId} marked paid (status -> CONFIRMED)`);
   }
 
   private async emitStatusChanged(payment: Payment): Promise<void> {

--- a/backend/src/modules/payments/payment.entity.ts
+++ b/backend/src/modules/payments/payment.entity.ts
@@ -47,6 +47,21 @@ export class Payment {
   @Column({ type: 'decimal', precision: 20, scale: 7 })
   amount: number;
 
+  // Portion of `amount` routed to the platform, as a second payment
+  // operation in the SAME diner-signed transaction as the restaurant's
+  // share (issue #316 / ADR 0004) — atomic with the primary payment, never
+  // a separately-failable step. 0 when no platform fee is configured.
+  @Column({ type: 'decimal', precision: 20, scale: 7, default: 0 })
+  platformFeeAmount: number;
+
+  // The platform fee address this payment actually used, recorded even
+  // though it's also in config — config can change after the fact, but a
+  // settled payment's real destination must stay traceable (issue #316
+  // acceptance criteria: "all traceable to one order"). Null when
+  // platformFeeAmount is 0 (no fee collected on this payment).
+  @Column({ type: 'varchar', length: 56, nullable: true })
+  platformFeeDestination: string | null;
+
   @Column({
     type: 'enum',
     enum: PaymentStatus,

--- a/backend/src/modules/payments/payments.gateway.ts
+++ b/backend/src/modules/payments/payments.gateway.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 import { PaymentStatus } from './payment.entity';
+import { LoyaltyPayoutStatus } from './loyalty-payout.entity';
 
 interface PaymentSocketUser {
   sub: string;
@@ -22,6 +23,16 @@ export interface PaymentStatusChangedEvent {
   paymentId: string;
   orderId: string;
   status: PaymentStatus;
+  stellarTxHash: string | null;
+  failureReason: string | null;
+  updatedAt: string;
+}
+
+export interface LoyaltyPayoutStatusChangedEvent {
+  payoutId: string;
+  paymentId: string;
+  orderId: string;
+  status: LoyaltyPayoutStatus;
   stellarTxHash: string | null;
   failureReason: string | null;
   updatedAt: string;
@@ -99,5 +110,14 @@ export class PaymentsGateway
     this.server
       .to(restaurantRoom(restaurantId))
       .emit('payment:status_changed', event);
+  }
+
+  emitLoyaltyPayoutStatusChanged(
+    restaurantId: string,
+    event: LoyaltyPayoutStatusChangedEvent,
+  ): void {
+    this.server
+      .to(restaurantRoom(restaurantId))
+      .emit('payout:status_changed', event);
   }
 }

--- a/backend/src/modules/payments/payments.module.ts
+++ b/backend/src/modules/payments/payments.module.ts
@@ -2,31 +2,35 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Payment } from './payment.entity';
+import { LoyaltyPayout } from './loyalty-payout.entity';
 import { Order } from '../orders/order.entity';
 import { Restaurant } from '../restaurant/restaurant.entity';
 import { StellarService } from './stellar.service';
 import { SequenceAllocator } from './sequence-allocator.service';
 import { PaymentsService } from './payments.service';
 import { PaymentsController } from './payments.controller';
+import { PayoutsController } from './payouts.controller';
 import { PaymentsGateway } from './payments.gateway';
 import { PaymentReconciliationService } from './payment-reconciliation.service';
+import { LoyaltyPayoutService } from './loyalty-payout.service';
 import { OrdersModule } from '../orders/orders.module';
 import { AuthModule } from '../auth/auth.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Payment, Order, Restaurant]),
+    TypeOrmModule.forFeature([Payment, LoyaltyPayout, Order, Restaurant]),
     OrdersModule,
     // PaymentsGateway needs JwtService directly — OrdersModule imports
     // AuthModule but doesn't re-export it, so it must be imported here too.
     AuthModule,
   ],
-  controllers: [PaymentsController],
+  controllers: [PaymentsController, PayoutsController],
   providers: [
     StellarService,
     SequenceAllocator,
     PaymentsService,
     PaymentsGateway,
+    LoyaltyPayoutService,
     PaymentReconciliationService,
   ],
   exports: [StellarService],

--- a/backend/src/modules/payments/payments.service.spec.ts
+++ b/backend/src/modules/payments/payments.service.spec.ts
@@ -37,11 +37,13 @@ describe('PaymentsService', () => {
   let restaurantRepository: MockRepository;
   let stellarService: {
     buildPaymentTransaction: jest.Mock;
+    buildSplitPaymentTransaction: jest.Mock;
     submitTransaction: jest.Mock;
     computeTransactionHash: jest.Mock;
   };
   let sequenceAllocator: { allocate: jest.Mock; invalidate: jest.Mock };
   let paymentsGateway: { emitPaymentStatusChanged: jest.Mock };
+  let configService: { get: jest.Mock };
   let service: PaymentsService;
 
   const order = {
@@ -65,6 +67,9 @@ describe('PaymentsService', () => {
     restaurantRepository = makeRepository();
     stellarService = {
       buildPaymentTransaction: jest.fn().mockResolvedValue('unsigned-xdr'),
+      buildSplitPaymentTransaction: jest
+        .fn()
+        .mockResolvedValue('unsigned-split-xdr'),
       submitTransaction: jest.fn(),
       computeTransactionHash: jest
         .fn()
@@ -75,6 +80,9 @@ describe('PaymentsService', () => {
       invalidate: jest.fn(),
     };
     paymentsGateway = { emitPaymentStatusChanged: jest.fn() };
+    // No platform fee configured by default — every existing test below
+    // exercises the original, unchanged single-operation transaction path.
+    configService = { get: jest.fn().mockReturnValue(undefined) };
 
     service = new PaymentsService(
       paymentRepository as any,
@@ -83,6 +91,7 @@ describe('PaymentsService', () => {
       stellarService as any,
       sequenceAllocator as any,
       paymentsGateway as any,
+      configService as any,
     );
 
     paymentRepository.findOne.mockResolvedValue(null);
@@ -190,6 +199,72 @@ describe('PaymentsService', () => {
       const result = await service.initiate(baseDto);
 
       expect(result.paymentId).toBe('raced-in-payment');
+    });
+  });
+
+  describe('initiate — platform fee split (issue #316)', () => {
+    function withFeeConfig(address: string | undefined, bps: string) {
+      configService.get.mockImplementation((key: string, fallback?: string) => {
+        if (key === 'PLATFORM_FEE_STELLAR_ADDRESS') return address;
+        if (key === 'PLATFORM_FEE_BPS') return bps;
+        return fallback;
+      });
+    }
+
+    it('builds a split transaction with restaurant net + platform fee legs when a fee is configured', async () => {
+      withFeeConfig('GPLATFORMFEE...', '250'); // 2.5%
+
+      const result = await service.initiate(baseDto);
+
+      expect(stellarService.buildSplitPaymentTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceAccount: 'GSOURCE...',
+          assetCode: 'XLM',
+          legs: [
+            { destinationAccount: 'GDEST...', amount: '9.7500000' },
+            { destinationAccount: 'GPLATFORMFEE...', amount: '0.2500000' },
+          ],
+          sequenceOverride: '101',
+        }),
+      );
+      expect(stellarService.buildPaymentTransaction).not.toHaveBeenCalled();
+      expect(paymentRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          platformFeeAmount: 0.25,
+          platformFeeDestination: 'GPLATFORMFEE...',
+        }),
+      );
+      expect(result.unsignedTransactionXdr).toBe('unsigned-split-xdr');
+    });
+
+    it('falls back to the original single-operation transaction when no fee address is configured', async () => {
+      withFeeConfig(undefined, '250');
+
+      await service.initiate(baseDto);
+
+      expect(stellarService.buildSplitPaymentTransaction).not.toHaveBeenCalled();
+      expect(stellarService.buildPaymentTransaction).toHaveBeenCalled();
+      expect(paymentRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ platformFeeAmount: 0, platformFeeDestination: null }),
+      );
+    });
+
+    it('falls back to the original transaction when the fee bps is zero', async () => {
+      withFeeConfig('GPLATFORMFEE...', '0');
+
+      await service.initiate(baseDto);
+
+      expect(stellarService.buildSplitPaymentTransaction).not.toHaveBeenCalled();
+      expect(stellarService.buildPaymentTransaction).toHaveBeenCalled();
+    });
+
+    it('ignores a misconfigured fee that would consume the entire payment rather than pay the restaurant nothing', async () => {
+      withFeeConfig('GPLATFORMFEE...', '10000'); // 100% — pathological
+
+      await service.initiate(baseDto);
+
+      expect(stellarService.buildSplitPaymentTransaction).not.toHaveBeenCalled();
+      expect(stellarService.buildPaymentTransaction).toHaveBeenCalled();
     });
   });
 

--- a/backend/src/modules/payments/payments.service.ts
+++ b/backend/src/modules/payments/payments.service.ts
@@ -1,5 +1,6 @@
 // backend/src/modules/payments/payments.service.ts
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { QueryFailedError, Repository } from 'typeorm';
 import { Order } from '../orders/order.entity';
@@ -37,6 +38,12 @@ export interface SubmitSignedPaymentResult {
   stellarTxHash: string | null;
 }
 
+interface FeeSplit {
+  netAmount: string;
+  feeAmount: string;
+  feeDestination: string;
+}
+
 @Injectable()
 export class PaymentsService {
   private readonly logger = new Logger(PaymentsService.name);
@@ -51,6 +58,7 @@ export class PaymentsService {
     private readonly stellarService: StellarService,
     private readonly sequenceAllocator: SequenceAllocator,
     private readonly paymentsGateway: PaymentsGateway,
+    private readonly configService: ConfigService,
   ) {}
 
   async initiate(dto: InitiatePaymentDto): Promise<InitiatePaymentResult> {
@@ -82,27 +90,88 @@ export class PaymentsService {
     }
 
     const sequence = await this.sequenceAllocator.allocate(dto.sourceAccount);
-    const unsignedTransactionXdr =
-      await this.stellarService.buildPaymentTransaction({
-        sourceAccount: dto.sourceAccount,
-        destinationAccount: restaurant.stellarWalletAddress,
-        assetCode: dto.assetCode,
-        assetIssuer: dto.assetIssuer,
-        amount: dto.amount,
-        memo: order.orderNumber,
-        sequenceOverride: sequence,
-      });
+    const split = this.computeFeeSplit(dto.amount);
+
+    // Platform fee, when configured, rides as a second Operation.payment
+    // in the SAME diner-signed transaction as the restaurant's share
+    // (issue #316 / ADR 0004) — one signature, atomic: both land or
+    // neither does. No fee configured (the default) is byte-for-byte the
+    // original single-operation transaction.
+    const unsignedTransactionXdr = split
+      ? await this.stellarService.buildSplitPaymentTransaction({
+          sourceAccount: dto.sourceAccount,
+          assetCode: dto.assetCode,
+          assetIssuer: dto.assetIssuer,
+          legs: [
+            {
+              destinationAccount: restaurant.stellarWalletAddress,
+              amount: split.netAmount,
+            },
+            {
+              destinationAccount: split.feeDestination,
+              amount: split.feeAmount,
+            },
+          ],
+          memo: order.orderNumber,
+          sequenceOverride: sequence,
+        })
+      : await this.stellarService.buildPaymentTransaction({
+          sourceAccount: dto.sourceAccount,
+          destinationAccount: restaurant.stellarWalletAddress,
+          assetCode: dto.assetCode,
+          assetIssuer: dto.assetIssuer,
+          amount: dto.amount,
+          memo: order.orderNumber,
+          sequenceOverride: sequence,
+        });
 
     const payment = await this.createPayment(
       dto,
       restaurant,
       unsignedTransactionXdr,
+      split,
     );
 
     return {
       paymentId: payment.id,
       status: payment.status,
       unsignedTransactionXdr,
+    };
+  }
+
+  /**
+   * Returns null when no platform fee is configured (PLATFORM_FEE_STELLAR_ADDRESS
+   * unset or PLATFORM_FEE_BPS <= 0) — the common/default case, which keeps
+   * `initiate()` on the original single-operation transaction path
+   * unchanged. Also returns null (with a warning) if a misconfigured bps
+   * would consume the entire payment, rather than build a transaction
+   * that pays the restaurant nothing.
+   */
+  private computeFeeSplit(amount: string): FeeSplit | null {
+    const feeDestination = this.configService.get<string>(
+      'PLATFORM_FEE_STELLAR_ADDRESS',
+    );
+    const feeBps = Number(
+      this.configService.get<string>('PLATFORM_FEE_BPS', '0'),
+    );
+    if (!feeDestination || !(feeBps > 0)) {
+      return null;
+    }
+
+    const total = Number(amount);
+    const fee = Math.round(((total * feeBps) / 10_000) * 1e7) / 1e7;
+    if (fee <= 0 || fee >= total) {
+      this.logger.warn(
+        `Ignoring platform fee config: computed fee ${fee} is invalid for amount ${amount} (PLATFORM_FEE_BPS=${feeBps})`,
+      );
+      return null;
+    }
+
+    const net = Math.round((total - fee) * 1e7) / 1e7;
+    return {
+      netAmount: net.toFixed(7),
+      feeAmount: fee.toFixed(7),
+      feeDestination,
     };
   }
 
@@ -115,6 +184,7 @@ export class PaymentsService {
     dto: InitiatePaymentDto,
     restaurant: Restaurant,
     unsignedTransactionXdr: string,
+    split: FeeSplit | null,
   ): Promise<Payment> {
     const payment = this.paymentRepository.create({
       orderId: dto.orderId,
@@ -126,6 +196,8 @@ export class PaymentsService {
       status: PaymentStatus.PENDING,
       horizonEnvelopeXdr: unsignedTransactionXdr,
       expiresAt: new Date(Date.now() + TRANSACTION_TIMEOUT_SECONDS * 1000),
+      platformFeeAmount: split ? Number(split.feeAmount) : 0,
+      platformFeeDestination: split ? split.feeDestination : null,
     });
 
     try {

--- a/backend/src/modules/payments/payouts.controller.ts
+++ b/backend/src/modules/payments/payouts.controller.ts
@@ -1,0 +1,96 @@
+// backend/src/modules/payments/payouts.controller.ts
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Post,
+  Request,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Throttle } from '@nestjs/throttler';
+import { Order } from '../orders/order.entity';
+import { LoyaltyPayout, LoyaltyPayoutStatus } from './loyalty-payout.entity';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { AdminRole } from '../auth/admin-user.entity';
+
+interface StaffRequest {
+  user: { restaurantId: string };
+}
+
+// Staff-facing — protected by the app's global JwtAuthGuard + RolesGuard
+// (see app.module.ts), the mirror image of PaymentsController's diner-
+// facing @Public() endpoints. Issue #316: "define who can trigger a
+// payout on a restaurant's behalf" (ADR 0004).
+@Controller('payments/:paymentId/payout')
+export class PayoutsController {
+  constructor(
+    @InjectRepository(LoyaltyPayout)
+    private readonly payoutRepository: Repository<LoyaltyPayout>,
+    @InjectRepository(Order)
+    private readonly orderRepository: Repository<Order>,
+  ) {}
+
+  // Read-only status check — no @Roles() restriction, same as
+  // AdminController.getDashboard: any authenticated staff member at the
+  // restaurant can see it, only the retry action below is a financial
+  // action gated by role.
+  @Get()
+  async findOne(
+    @Param('paymentId') paymentId: string,
+    @Request() req: StaffRequest,
+  ): Promise<LoyaltyPayout> {
+    return this.findScoped(paymentId, req.user.restaurantId);
+  }
+
+  /**
+   * Manual retry. LoyaltyPayoutService's scheduled job already retries a
+   * FAILED payout automatically once its backoff window elapses — this
+   * exists for an ops-visible "retry now" action, restricted to managers
+   * and above (a financial trigger, unlike the read-only status check).
+   * No-op (not an error) if the payout isn't currently FAILED, matching
+   * PaymentsService.submitSigned's idempotent-replay shape.
+   */
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
+  @Post('retry')
+  @Roles(AdminRole.MANAGER, AdminRole.ADMIN, AdminRole.SUPER_ADMIN)
+  async retry(
+    @Param('paymentId') paymentId: string,
+    @Request() req: StaffRequest,
+  ): Promise<LoyaltyPayout> {
+    const payout = await this.findScoped(paymentId, req.user.restaurantId);
+    if (payout.status !== LoyaltyPayoutStatus.FAILED) {
+      return payout;
+    }
+
+    // Clears the backoff wait so the next scheduled tick (at most a few
+    // seconds away) picks it up immediately, instead of a staff member
+    // waiting out whatever backoff window it was already in.
+    payout.lastAttemptAt = null;
+    return this.payoutRepository.save(payout);
+  }
+
+  private async findScoped(
+    paymentId: string,
+    restaurantId: string,
+  ): Promise<LoyaltyPayout> {
+    const payout = await this.payoutRepository.findOne({
+      where: { paymentId },
+    });
+    if (!payout) {
+      throw new NotFoundException('Loyalty payout not found for this payment');
+    }
+
+    // Either the order doesn't exist or belongs to a different restaurant
+    // — 404 either way, so this never leaks cross-restaurant existence.
+    const order = await this.orderRepository.findOne({
+      where: { id: payout.orderId, restaurantId },
+    });
+    if (!order) {
+      throw new NotFoundException('Loyalty payout not found for this payment');
+    }
+
+    return payout;
+  }
+}

--- a/backend/src/modules/payments/stellar.service.spec.ts
+++ b/backend/src/modules/payments/stellar.service.spec.ts
@@ -157,6 +157,90 @@ describe('StellarService', () => {
     });
   });
 
+  describe('buildSplitPaymentTransaction (issue #316)', () => {
+    it('builds one Operation.payment per leg in a single atomic transaction', async () => {
+      const service = readyService();
+      mockLoadAccount.mockResolvedValueOnce(
+        new Account(sourceKeypair.publicKey(), '100'),
+      );
+      mockFetchBaseFee.mockResolvedValueOnce(100);
+
+      const feeKeypair = Keypair.random();
+      const xdr = await service.buildSplitPaymentTransaction({
+        sourceAccount: sourceKeypair.publicKey(),
+        assetCode: 'XLM',
+        legs: [
+          { destinationAccount: destinationKeypair.publicKey(), amount: '9.7500000' },
+          { destinationAccount: feeKeypair.publicKey(), amount: '0.2500000' },
+        ],
+      });
+
+      const { TransactionBuilder, Networks: N } = jest.requireActual(
+        '@stellar/stellar-sdk',
+      );
+      const parsed = TransactionBuilder.fromXDR(xdr, N.TESTNET);
+
+      expect(parsed.operations).toHaveLength(2);
+      expect(parsed.operations[0]).toMatchObject({
+        type: 'payment',
+        destination: destinationKeypair.publicKey(),
+        amount: '9.7500000',
+      });
+      expect(parsed.operations[1]).toMatchObject({
+        type: 'payment',
+        destination: feeKeypair.publicKey(),
+        amount: '0.2500000',
+      });
+    });
+
+    it('throws when called with zero legs', async () => {
+      const service = readyService();
+      await expect(
+        service.buildSplitPaymentTransaction({
+          sourceAccount: sourceKeypair.publicKey(),
+          assetCode: 'XLM',
+          legs: [],
+        }),
+      ).rejects.toThrow(/at least one leg is required/);
+      expect(mockLoadAccount).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('signTransactionWithKeypair (issue #316)', () => {
+    it('signs an unsigned envelope, producing a transaction with one more signature', async () => {
+      const service = readyService();
+      mockLoadAccount.mockResolvedValueOnce(
+        new Account(sourceKeypair.publicKey(), '100'),
+      );
+      mockFetchBaseFee.mockResolvedValueOnce(100);
+
+      const unsignedXdr = await service.buildPaymentTransaction({
+        sourceAccount: sourceKeypair.publicKey(),
+        destinationAccount: destinationKeypair.publicKey(),
+        assetCode: 'XLM',
+        amount: '1.0000000',
+      });
+
+      const signedXdr = service.signTransactionWithKeypair(
+        unsignedXdr,
+        sourceKeypair,
+      );
+
+      const { TransactionBuilder, Networks: N } = jest.requireActual(
+        '@stellar/stellar-sdk',
+      );
+      const unsignedParsed = TransactionBuilder.fromXDR(unsignedXdr, N.TESTNET);
+      const signedParsed = TransactionBuilder.fromXDR(signedXdr, N.TESTNET);
+
+      expect(unsignedParsed.signatures).toHaveLength(0);
+      expect(signedParsed.signatures).toHaveLength(1);
+      // Same underlying transaction — signing must not alter its hash.
+      expect(signedParsed.hash().toString('hex')).toBe(
+        unsignedParsed.hash().toString('hex'),
+      );
+    });
+  });
+
   describe('submitTransaction', () => {
     it('parses the signed XDR and submits it to Horizon', async () => {
       const service = readyService();

--- a/backend/src/modules/payments/stellar.service.ts
+++ b/backend/src/modules/payments/stellar.service.ts
@@ -5,10 +5,12 @@ import {
   Account,
   Asset,
   Horizon,
+  Keypair,
   Memo,
   Networks,
   NotFoundError,
   Operation,
+  Transaction,
   TransactionBuilder,
 } from '@stellar/stellar-sdk';
 
@@ -30,6 +32,22 @@ export interface BuildPaymentTransactionParams {
    * this must not also expect the usual +1 — buildPaymentTransaction
    * compensates by constructing the Account one below this value.
    */
+  sequenceOverride?: string;
+}
+
+export interface PaymentSplitLeg {
+  destinationAccount: string;
+  /** Decimal string, e.g. "12.5000000" — never a float. */
+  amount: string;
+}
+
+export interface BuildSplitPaymentTransactionParams {
+  sourceAccount: string;
+  assetCode: string;
+  assetIssuer?: string;
+  /** One `Operation.payment` per leg, all sharing one asset/source/signature (issue #316 / ADR 0004) — e.g. [restaurant net amount, platform fee]. At least one leg required. */
+  legs: PaymentSplitLeg[];
+  memo?: string;
   sequenceOverride?: string;
 }
 
@@ -127,6 +145,40 @@ export class StellarService implements OnModuleInit {
   async buildPaymentTransaction(
     params: BuildPaymentTransactionParams,
   ): Promise<string> {
+    return this.buildMultiOperationPayment({
+      sourceAccount: params.sourceAccount,
+      assetCode: params.assetCode,
+      assetIssuer: params.assetIssuer,
+      legs: [
+        { destinationAccount: params.destinationAccount, amount: params.amount },
+      ],
+      memo: params.memo,
+      sequenceOverride: params.sequenceOverride,
+    });
+  }
+
+  /**
+   * Builds an unsigned transaction with one `Operation.payment` per leg,
+   * all sharing a single source/asset/signature — e.g. a diner's payment
+   * split into a restaurant-net-amount leg and a platform-fee leg in one
+   * atomic, once-signed transaction (issue #316 / ADR 0004: "so it can't
+   * partially apply"). Returns a base64 XDR envelope, same as
+   * buildPaymentTransaction.
+   */
+  async buildSplitPaymentTransaction(
+    params: BuildSplitPaymentTransactionParams,
+  ): Promise<string> {
+    if (params.legs.length === 0) {
+      throw new Error(
+        'StellarService.buildSplitPaymentTransaction: at least one leg is required',
+      );
+    }
+    return this.buildMultiOperationPayment(params);
+  }
+
+  private async buildMultiOperationPayment(
+    params: BuildSplitPaymentTransactionParams,
+  ): Promise<string> {
     const sourceAccount = params.sequenceOverride
       ? new Account(
           params.sourceAccount,
@@ -139,21 +191,42 @@ export class StellarService implements OnModuleInit {
         ? Asset.native()
         : new Asset(params.assetCode, params.assetIssuer);
 
-    const transaction = new TransactionBuilder(sourceAccount, {
+    let builder = new TransactionBuilder(sourceAccount, {
       fee: String(baseFee),
       networkPassphrase: this.networkPassphrase,
-    })
-      .addOperation(
+    });
+
+    for (const leg of params.legs) {
+      builder = builder.addOperation(
         Operation.payment({
-          destination: params.destinationAccount,
+          destination: leg.destinationAccount,
           asset,
-          amount: params.amount,
+          amount: leg.amount,
         }),
-      )
+      );
+    }
+
+    const transaction = builder
       .addMemo(params.memo ? Memo.text(params.memo) : Memo.none())
       .setTimeout(TRANSACTION_TIMEOUT_SECONDS)
       .build();
 
+    return transaction.toXDR();
+  }
+
+  /**
+   * Signs an unsigned transaction envelope with a platform-held Keypair —
+   * the ONLY place StellarService touches a private key directly (issue
+   * #316 / ADR 0004: loyalty payouts are a platform-signed transaction,
+   * unlike the diner-signed primary payment ADR 0001 covers). Callers own
+   * the Keypair's lifecycle; this method never logs or persists it.
+   */
+  signTransactionWithKeypair(unsignedXdr: string, keypair: Keypair): string {
+    const transaction = TransactionBuilder.fromXDR(
+      unsignedXdr,
+      this.networkPassphrase,
+    ) as Transaction;
+    transaction.sign(keypair);
     return transaction.toXDR();
   }
 

--- a/docs/adr/0004-platform-fee-and-loyalty-distribution.md
+++ b/docs/adr/0004-platform-fee-and-loyalty-distribution.md
@@ -1,0 +1,115 @@
+# ADR 0004: Platform fee collection and loyalty token distribution
+
+- **Status:** Accepted
+- **Date:** 2026-08-22
+- **Related issue:** #316
+
+## Context
+
+ADR 0001 decided payment collection is non-custodial and explicitly deferred
+two questions rather than answering them: "If a future issue needs a
+platform-controlled account (e.g. ... to collect a platform fee via a path
+payment), that is a new, narrower decision to make explicitly when that
+need actually arises." Issue #316 is that future issue — it needs both a
+platform fee split and, per the README's worked example, automatic loyalty
+token issuance to the diner after a confirmed payment. Neither exists in
+the codebase today; this ADR makes the narrower decision ADR 0001 deferred.
+
+## Decision
+
+**Platform fee: no new custodial key.** The fee is collected as a second
+`Operation.payment` in the *same* transaction the diner already builds and
+signs once (`StellarService.buildSplitPaymentTransaction`) — one operation
+pays the restaurant's net amount, the other pays
+`PLATFORM_FEE_STELLAR_ADDRESS`. Both land or neither does; there is no
+"payment succeeded but fee collection failed" state to reconcile, because
+it was never two transactions. This keeps ADR 0001's non-custodial decision
+completely intact — the diner is still the only signer, for both legs.
+
+**Loyalty distribution: a new, narrowly-scoped platform-controlled
+account.** Sending a loyalty asset to the diner is fundamentally a payment
+*from* the platform, which no diner signature can authorize. This
+unavoidably requires a platform-held Stellar secret key
+(`LOYALTY_ISSUER_SECRET`), used for exactly one thing: signing the
+platform's own loyalty-asset payouts. It never touches a diner's or
+restaurant's account or key material — this is the platform operating its
+own wallet, the same way a restaurant operates its own
+`stellarWalletAddress`, not custody of anyone else's funds. It is
+deliberately **not** a revival of the never-adopted `STELLAR_MASTER_SECRET`
+from the README/`.env.example` — that name implied broad, undefined
+custodial authority; this key's scope is fixed to loyalty payouts and
+named accordingly.
+
+Because a payout is a genuinely separate transaction from the (now
+possibly-atomic) primary payment, it needs its own idempotent,
+independently-retryable lifecycle — `LoyaltyPayout` gets its own status
+machine (`loyalty-payout-state-machine.ts`), mirroring `Payment`'s
+`pending -> submitted -> confirmed | failed` shape from ADR 0003, with one
+difference: `failed -> submitted` is a legal transition here (a fresh
+submission attempt with a new sequence number), driven by
+`LoyaltyPayoutService`'s own scheduled job, so a payout failure recovers
+automatically instead of being a dead end. One `LoyaltyPayout` row per
+`Payment` is enforced at the DB level (`paymentId` unique), the same
+belt-and-suspenders pattern `Payment.idempotencyKey` uses — a payout can
+never be double-issued for the same payment, no matter how many times
+reconciliation re-processes it.
+
+**Scope for this issue: one platform-wide loyalty asset, not per-restaurant
+custom tokens.** The README's longer-term vision ("Restaurants issue custom
+tokens as loyalty rewards," "Launch your own restaurant loyalty token")
+would mean holding a *distinct* issuing key per restaurant — a much larger
+custodial surface (many secrets, many restaurants' worth of key-management
+and security review) that ADR 0001 already flagged as out of scope for v1
+("it requires key-management infrastructure, custody/security review, and
+likely regulatory exposure... that nothing in the current codebase or
+roadmap justifies yet"). This issue delivers the single-asset version
+(`LOYALTY_ASSET_CODE`, default `BITE`, one issuer) sufficient to
+demonstrate the full settlement flow end-to-end. Per-restaurant tokens are
+a distinct future decision, deserving its own ADR and security review, not
+folded into this one by default — same reasoning ADR 0001 applied to
+custodial diner onboarding.
+
+**Fee rate and loyalty rate are both configurable, not hardcoded.**
+`PLATFORM_FEE_BPS` (default `0`, i.e. no fee unless an operator configures
+`PLATFORM_FEE_STELLAR_ADDRESS`) and `LOYALTY_RATE_BPS` (default `1000` =
+10%, matching the README's worked example `loyaltyRate = 0.10` exactly).
+Neither figure is specified anywhere else in this codebase or its docs;
+these are placeholder defaults to be tuned to real business terms, not a
+claim that 10%/0% are the "correct" rates.
+
+## Alternatives considered
+
+- **Fee via a separate platform-signed payout job**, mirroring loyalty's
+  design. Rejected: it would need its own custodial key for money that
+  originates from the diner, when the diner is already signing a
+  transaction right there — needlessly widening custodial scope for no
+  benefit over folding it into the same atomic, diner-signed transaction.
+- **Loyalty via a pre-funded distribution account instead of an issuing
+  account** (avoids `Operation.payment` needing the issuer specifically).
+  Not adopted for this issue: it adds an extra funding/top-up operational
+  concern (the distribution account running dry) without removing the
+  core custodial-key requirement this ADR already accepts is unavoidable —
+  a real optimization, but orthogonal to the decision this ADR needs to
+  make, so left as a documented follow-up rather than scope creep here.
+
+## Consequences
+
+- `LOYALTY_ISSUER_SECRET` is the only new secret this issue introduces. It
+  is loaded once at boot (`LoyaltyPayoutService.onModuleInit`, fail-fast —
+  mirroring `StellarService`'s existing pattern), held only as a decoded
+  `Keypair` in memory, and never appears in any log line, thrown error, or
+  API response — audited explicitly in
+  `loyalty-payout.service.spec.ts`.
+- `SequenceAllocator` (already generic per-account) is reused for the
+  loyalty issuer account, since every restaurant's confirmed orders share
+  that one account and would otherwise race the same
+  read-then-increment sequence problem it already solves for diner
+  accounts (issue #313).
+- `Order.status` gains a concrete meaning for `CONFIRMED` (previously
+  declared but unused anywhere in the codebase): a `Payment` reconciling to
+  `CONFIRMED` flips its `Order` from `PENDING` to `CONFIRMED` — "paid." No
+  new enum value was needed.
+- Staff-triggered payout visibility/retry (`PayoutsController`) is scoped
+  to `AdminRole.MANAGER` and above, restaurant-scoped via
+  `req.user.restaurantId`, mirroring `AdminController`'s existing pattern —
+  `AdminRole.STAFF` cannot trigger a financial retry action.

--- a/docs/payment-settlement-demo-checklist.md
+++ b/docs/payment-settlement-demo-checklist.md
@@ -1,0 +1,107 @@
+# Payment settlement demo checklist (issue #316)
+
+A repeatable, end-to-end walkthrough of order → wallet-signed payment →
+confirmed → funds distributed (restaurant + platform fee + loyalty token)
+→ order marked paid, on Stellar testnet, through the real UI and API —
+not a script. See `docs/adr/0001-payment-custody-model.md`,
+`docs/adr/0003-payment-confirmation-reconciliation.md`, and
+`docs/adr/0004-platform-fee-and-loyalty-distribution.md` for the
+architecture this exercises.
+
+## Prerequisites
+
+- [ ] Backend running with `STELLAR_NETWORK=testnet` and a reachable
+      `STELLAR_HORIZON_URL` (see `backend/.env.example`).
+- [ ] `LOYALTY_ISSUER_SECRET` set to a funded testnet keypair (fund via
+      [Friendbot](https://laboratory.stellar.org/#account-creator?network=test)),
+      and the loyalty asset (`LOYALTY_ASSET_CODE`, default `BITE`) issued
+      from that same account.
+- [ ] Optional, to also exercise the fee split: `PLATFORM_FEE_STELLAR_ADDRESS`
+      set to a funded testnet account, `PLATFORM_FEE_BPS` > 0 (e.g. `250`
+      for 2.5%).
+- [ ] A restaurant record with `stellarWalletAddress` set to a funded
+      testnet account.
+- [ ] The diner's own wallet (Freighter) installed, switched to Testnet,
+      funded via Friendbot, and — if paying in a non-XLM asset — a
+      trustline already established for that asset (the checkout UI's
+      trustline-setup step, issue #315, or manually via Stellar Laboratory).
+- [ ] The diner's wallet also holds a trustline for the loyalty asset
+      (`LOYALTY_ASSET_CODE`/its issuer) — otherwise the loyalty payout will
+      correctly and repeatedly fail with `MISSING_TRUSTLINE` until one is
+      added; that failure mode is itself worth demonstrating once (see
+      "Fallback / retry procedure" below).
+
+## Walkthrough
+
+1. **Place an order** through the real diner-facing flow (order
+   notification → checkout). Note the `orderId`.
+2. **Open checkout** for that order and connect the diner's wallet
+   (Freighter) via the UI.
+3. **Pay**: confirm the payment in the UI. This calls
+   `POST /payments/stellar/initiate`, gets back an unsigned XDR envelope
+   (single-operation, or two operations if a platform fee is configured —
+   inspect the XDR in Stellar Laboratory to see both `Operation.payment`
+   legs sharing one signature), signs it with the connected wallet, and
+   submits it via `POST /payments/stellar/:paymentId/submit-signed`.
+4. **Watch confirmation happen live**: the payment status moves
+   `pending -> submitted -> confirmed` in the UI, driven by
+   `PaymentReconciliationService`'s polling (~10s cadence) — no manual
+   refresh needed if the payments WebSocket (`/payments` namespace) is
+   connected; the reconnect-safe `GET /payments/stellar/:paymentId`
+   fallback works identically if it isn't.
+5. **Confirm on-chain funds movement directly** (not just via the API) —
+   look up both destination accounts on
+   [Stellar Expert](https://stellar.expert/explorer/testnet) or Stellar
+   Laboratory:
+   - [ ] The restaurant's `stellarWalletAddress` balance increased by the
+         net amount (full amount minus fee, if a fee is configured).
+   - [ ] If a fee is configured, `PLATFORM_FEE_STELLAR_ADDRESS` balance
+         increased by the fee amount, in the **same transaction hash** as
+         the restaurant's payment (proving the atomic split — one
+         transaction, two operations).
+6. **Watch the loyalty payout happen live**: within a few seconds of
+   confirmation, `LoyaltyPayoutService`'s own cron tick submits a separate,
+   platform-signed transaction. Watch the diner's wallet balance for the
+   loyalty asset (`LOYALTY_ASSET_CODE`) increase by 10% of the payment
+   amount (the README's worked-example rate, `LOYALTY_RATE_BPS=1000` by
+   default) — or check `GET /payments/:paymentId/payout` (staff-facing,
+   requires an authenticated admin session) for its status transitioning
+   `pending -> submitted -> confirmed`.
+7. **Confirm the order flips to paid**: the restaurant-side order view
+   shows the order's status moved from `pending` to `confirmed` —
+   `PaymentReconciliationService` does this the moment the payment
+   confirms, in the same reconciliation pass (see ADR 0004).
+8. **All traceable to one order**: from the `orderId`, you should be able
+   to reach — the `Payment` row (with `platformFeeAmount`/
+   `platformFeeDestination` if applicable), its `stellarTxHash`, the
+   `LoyaltyPayout` row (`paymentId` foreign key), and its own
+   `stellarTxHash` — three independently-verifiable on-chain facts, one
+   order.
+
+## Fallback / retry procedure (testnet Horizon flakiness)
+
+Testnet Horizon occasionally rate-limits or drops requests. This flow is
+built to tolerate that without a diner ever seeing a false "failed":
+
+- If **submission** returns an ambiguous error (timeout, dropped
+  connection), the payment stays `submitted` — reconciliation resolves it
+  by independently checking Horizon by hash on its next tick. No action
+  needed; just wait and re-check status.
+- If **confirmation polling** hasn't resolved after 180s (the transaction's
+  own timebounds — `TRANSACTION_TIMEOUT_SECONDS`), the payment is marked
+  `expired`, not `failed` — this means "never charged," safe to retry the
+  payment from step 3.
+- If a **loyalty payout** fails (e.g. Horizon hiccup, or a missing
+  trustline on the diner's wallet), `LoyaltyPayoutService` retries it
+  automatically with exponential backoff (30s, 60s, 120s, up to a 300s
+  cap) — no re-run of the primary payment needed. To force an immediate
+  retry during a live demo instead of waiting out the backoff,
+  `POST /payments/:paymentId/payout/retry` (staff-facing, manager role or
+  above) clears the backoff so the next ~10s tick picks it up.
+- If you need to demonstrate the failure-and-recovery path deliberately:
+  temporarily remove the diner's loyalty-asset trustline before paying,
+  confirm the payout lands in `failed` with a `MISSING_TRUSTLINE`-shaped
+  reason, add the trustline back, then either wait for the next backoff
+  window or use the manual retry endpoint above — it should reach
+  `confirmed` without ever creating a second `LoyaltyPayout` row for the
+  same payment (the `paymentId` unique constraint).


### PR DESCRIPTION
## Summary

Closes #316.

Delivers the capstone of the payment track: an order → wallet-signed payment → confirmed → funds distributed (restaurant + platform fee + loyalty token) → order marked paid flow on testnet, with the authorization/operational safeguards a real money-movement path requires. Depends on (and builds directly on top of) #312, #313, #314, #315 — all already merged.

### Architecture decision (ADR 0004)

ADR 0001 (payment custody model) explicitly deferred the "does the platform ever hold a signing key" question for exactly this issue: *"If a future issue needs a platform-controlled account (e.g. ... to collect a platform fee via a path payment), that is a new, narrower decision to make explicitly when that need actually arises."* `docs/adr/0004-platform-fee-and-loyalty-distribution.md` makes that decision:

- **Platform fee: no new custodial key.** Collected as a second `Operation.payment` in the *same* transaction the diner already signs once (`StellarService.buildSplitPaymentTransaction`) — one leg pays the restaurant's net amount, one pays `PLATFORM_FEE_STELLAR_ADDRESS`. Both land or neither does; there's no "payment succeeded but fee collection failed" state to reconcile, because it was never two transactions. ADR 0001's non-custodial decision stays completely intact.
- **Loyalty distribution: one new, narrowly-scoped platform key.** Sending a loyalty asset to the diner is inherently a payment *from* the platform — no diner signature can authorize that. `LOYALTY_ISSUER_SECRET` is used for exactly this, nothing else, and is deliberately not a revival of the never-adopted `STELLAR_MASTER_SECRET`.
- **Scope for this issue: one platform-wide loyalty asset** (`LOYALTY_ASSET_CODE`, default `BITE`), not the README's longer-term per-restaurant custom tokens — that's a much larger custodial surface (one key per restaurant) deserving its own ADR and security review, same reasoning ADR 0001 applied to custodial diner onboarding.

### What's implemented

- **`StellarService.buildSplitPaymentTransaction`**: one atomic, once-signed, multi-operation transaction for the restaurant/fee split (extracted a shared private builder so `buildPaymentTransaction`'s existing behavior/tests are untouched).
- **`LoyaltyPayout` entity + its own state machine** (`pending -> submitted -> confirmed | failed`, with `failed -> submitted` legal — unlike `Payment`, a failed payout retries itself). One row per `Payment`, enforced at the DB level (`paymentId` unique), same belt-and-suspenders pattern as `Payment.idempotencyKey`.
- **`LoyaltyPayoutService`**: a scheduled job (mirroring `PaymentReconciliationService`'s submit/confirm shape) that builds, signs with the platform's loyalty issuer key, submits, and independently re-verifies against Horizon by hash — with exponential backoff (30s → 300s cap) on retry.
- **`PaymentReconciliationService`**: the moment a `Payment` reconciles to `CONFIRMED`, it now also flips `Order.status` `PENDING -> CONFIRMED` ("paid") and creates the loyalty payout — both wrapped so a hiccup in either can never roll back the payment's own already-saved status.
- **`PayoutsController`**: staff-facing, restaurant-scoped (mirrors `AdminController`'s `req.user.restaurantId` pattern), a manual retry endpoint gated to `MANAGER`+ (a financial action), throttled like the rest of the payments surface. Read-only status check is open to any authenticated staff member, matching `AdminController.getDashboard`'s existing convention.
- **Secrets audit**: `LOYALTY_ISSUER_SECRET` loads once at boot (fail-fast, mirroring `StellarService.onModuleInit`), lives only as a decoded `Keypair` in memory, and is never logged or echoed — even on an invalid-secret error, the thrown message is a fresh string, never the SDK's own (which could echo fragments of malformed input). Covered directly by a spy-on-`Logger` test asserting the raw secret never appears in any log call.
- **`docs/payment-settlement-demo-checklist.md`**: a repeatable testnet walkthrough (place order → connect wallet → pay → watch confirmation + fee split + loyalty credit happen live → order flips to paid), including a documented fallback/retry procedure for Horizon flakiness and a deliberate failure-and-recovery demo (missing trustline → automatic/manual retry → confirmed, without ever double-issuing).

New env vars (`backend/.env.example`): `PLATFORM_FEE_STELLAR_ADDRESS`, `PLATFORM_FEE_BPS` (both optional — no fee unless set), `LOYALTY_ISSUER_SECRET` (required), `LOYALTY_ASSET_CODE` (default `BITE`), `LOYALTY_RATE_BPS` (default `1000` = 10%, matching the README's worked example `loyaltyRate = 0.10` exactly).

## Test plan

- [x] `loyalty-payout-state-machine.spec.ts` — full transition-table coverage, including the two ways this machine differs from `Payment`'s.
- [x] `loyalty-payout.service.spec.ts` — secret fail-fast + never-logged (spy-based), idempotent creation (DB unique-violation race), submit/confirm happy path, definitive-vs-ambiguous submit-error handling, backoff-gated retry, and the specific idempotent-recovery scenario the acceptance criteria calls for (failed payout → retried → confirmed, exactly one row throughout) plus a regression test for a payout that fails again before ever reaching SUBMITTED.
- [x] Extended `payments.service.spec.ts` — fee-split leg computation, and confirms the no-fee-configured path is byte-for-byte the original single-operation transaction (all pre-existing tests pass unchanged).
- [x] Extended `stellar.service.spec.ts` — `buildSplitPaymentTransaction` produces one operation per leg in a single transaction; `signTransactionWithKeypair` adds exactly one signature without altering the transaction hash.
- [x] Extended `payment-reconciliation.service.spec.ts` — order-paid flip, loyalty payout creation trigger, idempotent re-run safety (won't clobber an order the kitchen already moved past PENDING), and a payout-service failure not rolling back the payment's CONFIRMED status.
- [ ] CI (`backend`, `frontend`, `contracts` jobs) — pending on this PR.